### PR TITLE
(chore): introduce multi-language releases like `java@1.0.1`, `ruby@0.0.1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Check Fern API is valid
         run: fern check
 
-  fern-generate:
+  fern-generate-ruby:
     needs: fern-check
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/ruby@')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -29,10 +29,36 @@ jobs:
       - name: Download Fern
         run: npm install -g fern-api
 
-      - name: Generate SDKs
+      - name: Release Go SDK
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: |
+          tag=${{ github.ref_name }}
+          prefix="ruby@"
+          SDK_VERSION="${tag#$prefix}"
+          fern generate --group ruby-sdk --version "$SDK_VERSION" --log-level debug
+
+  fern-generate-java:
+    needs: fern-check
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/java@')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+
+      - name: Download Fern
+        run: npm install -g fern-api
+
+      - name: Release Java SDK
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-        run: fern generate --group publish --log-level debug --version ${{ github.ref_name }}
+        run: |
+          tag=${{ github.ref_name }}
+          prefix="java@"
+          SDK_VERSION="${tag#$prefix}"
+          fern generate --group java-sdk --version "$SDK_VERSION" --log-level debug


### PR DESCRIPTION
Releases must be prefixed with `java@` and `ruby@` to target different languages. 