### PR TITLE
🌿 Introduce full Ruby SDK generation

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "assemblyai",
-  "version": "0.16.39"
+  "version": "0.16.43"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -12,14 +12,17 @@ groups:
           path: ../postman
   ruby-sdk:
     generators:
-      - name: fernapi/fern-ruby-model
-        version: 0.0.6
+      - name: fernapi/fern-ruby-sdk
+        version: 0.0.5-3220-4317f818f
         github:
           repository: AssemblyAI/assemblyai-ruby-sdk
           mode: pull-request
+        output:
+          location: rubygems
+          package-name: assemblyai
+          api-key: ${RUBYGEMS_API_KEY}
         config:
           clientClassName: AssemblyAI
-          gemName: assemblyai
   csharp-sdk:
     generators:
       - name: fernapi/fern-csharp-sdk

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -13,7 +13,7 @@ groups:
   ruby-sdk:
     generators:
       - name: fernapi/fern-ruby-sdk
-        version: 0.0.5-3220-4317f818f
+        version: 0.0.5-3606-1b81d99df
         github:
           repository: AssemblyAI/assemblyai-ruby-sdk
           mode: pull-request


### PR DESCRIPTION
As well as update the gem naming to be moved to the `output` block, mirroring the other Fern generators