### PR TITLE
(chore): ugprade fern to 0.17.4

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "assemblyai",
-  "version": "0.17.3"
+  "version": "0.17.4"
 }


### PR DESCRIPTION
Capitializing abbreviations will only be applied to Ruby (not C#/Java)