### PR TITLE
(chore): upgrade fern to `0.17.6` to support nuget output reading

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "assemblyai",
-  "version": "0.17.4"
+  "version": "0.17.6"
 }


### PR DESCRIPTION
Previously the CLI was incorrectly parsing the `nuget` output mode.  