### PR TITLE
🌿 upgrade Ruby generator to support future versions of the Fern CLI

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -13,7 +13,7 @@ groups:
   ruby-sdk:
     generators:
       - name: fernapi/fern-ruby-sdk
-        version: 0.0.6
+        version: 0.1.1
         github:
           repository: AssemblyAI/assemblyai-ruby-sdk
           mode: pull-request


### PR DESCRIPTION
This version fixes a hard dependency the Ruby generator had on a past version of the Fern CLI