### PR TITLE
(feat): configure display names

### DIFF
--- a/fern/asyncapi-overrides.yml
+++ b/fern/asyncapi-overrides.yml
@@ -1,0 +1,3 @@
+channels:
+  /v2/realtime/ws:
+    x-fern-display-name: Streaming

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "assemblyai",
-  "version": "0.19.21"
+  "version": "0.19.23"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -1,7 +1,9 @@
 default-group: local
-async-api: ../asyncapi.yml
-openapi: ../openapi.yml
-openapi-overrides: ./openapi-overrides.yml
+api: 
+  - path: ../asyncapi.yml
+    overrides: ./asyncapi-overrides.yml
+  - path: ../openapi.yml
+    overrides: ./openapi-overrides.yml
 groups:
   local:
     generators:

--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -1,3 +1,10 @@
+x-fern-groups: 
+  transcript: 
+    summary: Transcript
+  lemur: 
+    summary: LeMUR
+  realtime: 
+    summary: Streaming
 components:
   schemas:
     Transcript:


### PR DESCRIPTION
Now the display name for lemur is `LeMur` and for realtime it is `Streaming`. 