### PR TITLE
(fix): setup csharp sdk generate action

### DIFF
--- a/.github/workflows/csharp-sdk.yml
+++ b/.github/workflows/csharp-sdk.yml
@@ -1,0 +1,29 @@
+name: Release C# SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version of the C# SDK that you would like to release"
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+
+      - name: Download Fern
+        run: npm install -g fern-api
+
+      - name: Release C# SDK
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          fern generate --group csharp-sdk --version ${{ inputs.version }} --log-level debug

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -29,7 +29,7 @@ groups:
   csharp-sdk:
     generators:
       - name: fernapi/fern-csharp-sdk
-        version: 0.1.0
+        version: 0.0.9
         output:
           location: nuget
           package-name: AssemblyAI


### PR DESCRIPTION
Updates generator to the correct version and sets up a github workflow trigger specifically for C#. 