### PR TITLE
:herb: Bump Ruby Generator to latest

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -15,7 +15,7 @@ groups:
   ruby-sdk:
     generators:
       - name: fernapi/fern-ruby-sdk
-        version: 0.6.0-rc0
+        version: 0.6.3
         github:
           repository: AssemblyAI/assemblyai-ruby-sdk
           mode: pull-request


### PR DESCRIPTION
This should address this issue: https://github.com/AssemblyAI/assemblyai-ruby-sdk/issues/31