### PR TITLE
bumps fern's CLI version from `0.39.5` to `0.39.10`

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
-  "organization": "assemblyai",
-  "version": "0.39.5"
+  "organization": "assemblyai", 
+  "version": "0.39.10"
 }


### PR DESCRIPTION
This PR bumps fern's CLI version from `0.39.5` to `0.39.10`, supporting the new posthog integration.