### PR TITLE
docs(api): clarify that only lemur requests are rate limited

### DIFF
--- a/fern/pages/overview.mdx
+++ b/fern/pages/overview.mdx
@@ -94,11 +94,11 @@ In the rare event of a transcription failure due to a server error, you may resu
 
 ## Rate limits
 
-To ensure the API remains available for all users, AssemblyAI limits the number of API requests you can make within a certain amount of time.
+To ensure the LeMUR API remains available for all users, you can only make a limited number of requests within a 60-second time window. Only LeMUR requests are rate limited.
 
-If you exceed the rate limit, the API will respond with a `429` status code.
+If you exceed the limit, the API will respond with a `429` status code.
 
-Some endpoints may have more restrictive rate limits. To determine the rate limit for a specific endpoint, check the response for the following headers:
+To see your remaining quota, check the following response headers:
 
 | Header                  | Description                                                                                |
 | ----------------------- | ------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
This PR clarifies that rate limits are only enforced for LeMUR requests.