### PR TITLE
fix: clarify minimum audio duration for transcription

### DIFF
--- a/fern/pages/overview.mdx
+++ b/fern/pages/overview.mdx
@@ -88,7 +88,7 @@ Common reasons why a transcription may fail include:
 - Audio data is corrupted or in an unsupported format. See [FAQ](https://www.assemblyai.com/docs/concepts/faq) for supported formats.
 - Audio URL is a webpage rather than a file. Only the [AssemblyAI Playground](https://www.assemblyai.com/playground) supports retrieving videos directly from YouTube links.
 - Audio URL isn't accessible from AssemblyAI's servers.
-- Audio duration is too short (less than 200 ms).
+- Audio duration is too short (less than 160ms).
 
 In the rare event of a transcription failure due to a server error, you may resubmit the file for transcription. If the problems persist after resubmitting, [let us know](mailto:support@assemblyai.com).
 


### PR DESCRIPTION
The correct minimum audio duration for our API is 160ms.