### PR TITLE
Sync from internal repo (2024/10/17)

### DIFF
--- a/fern/.definition/__package__.yml
+++ b/fern/.definition/__package__.yml
@@ -3,22 +3,37 @@ errors:
     status-code: 400
     type: Error
     docs: Bad request
+    examples:
+      - value:
+          error: This is a sample error message
   UnauthorizedError:
     status-code: 401
     type: Error
     docs: Unauthorized
+    examples:
+      - value:
+          error: Authentication error, API token missing/invalid
   NotFoundError:
     status-code: 404
     type: Error
     docs: Not found
+    examples:
+      - value:
+          error: Not found
   TooManyRequestsError:
     status-code: 429
     type: Error
     docs: Too many requests
+    examples:
+      - value:
+          error: Too Many Requests
   InternalServerError:
     status-code: 500
     type: Error
     docs: An error occurred while processing the request
+    examples:
+      - value:
+          error: Internal Server Error
   ServiceUnavailableError:
     status-code: 503
     type: unknown
@@ -34,5 +49,6 @@ types:
         type: string
         docs: Error message
       status: optional<literal<"error">>
+    extra-properties: true
     source:
       openapi: ../openapi.yml

--- a/fern/.definition/lemur.yml
+++ b/fern/.definition/lemur.yml
@@ -21,6 +21,7 @@ service:
                 including any context you want to pass into the model.
           extends:
             - LemurBaseParams
+        content-type: application/json
       response:
         docs: LeMUR task response
         type: LemurTaskResponse
@@ -37,7 +38,7 @@ service:
             transcript_ids:
               - 64nygnr62k-405c-4ae8-8a6b-d90b40ff3cce
             context: This is an interview about wildfires.
-            final_model: default
+            final_model: anthropic/claude-3-5-sonnet
             max_output_size: 3000
             temperature: 0
             prompt: List all the locations affected by wildfires.
@@ -88,6 +89,7 @@ service:
                 Examples: "TLDR", "bullet points"
           extends:
             - LemurBaseParams
+        content-type: application/json
       response:
         docs: LeMUR summary response
         type: LemurSummaryResponse
@@ -104,7 +106,7 @@ service:
             transcript_ids:
               - 47b95ba5-8889-44d8-bc80-5de38306e582
             context: This is an interview about wildfires.
-            final_model: default
+            final_model: anthropic/claude-3-5-sonnet
             max_output_size: 3000
             temperature: 0
           response:
@@ -163,6 +165,7 @@ service:
               type: list<LemurQuestion>
           extends:
             - LemurBaseParams
+        content-type: application/json
       response:
         docs: LeMUR question & answer response
         type: LemurQuestionAnswerResponse
@@ -179,7 +182,7 @@ service:
             transcript_ids:
               - 64nygnr62k-405c-4ae8-8a6b-d90b40ff3cce
             context: This is an interview about wildfires.
-            final_model: default
+            final_model: anthropic/claude-3-5-sonnet
             max_output_size: 3000
             temperature: 0
             questions:
@@ -223,6 +226,7 @@ service:
               default: Bullet Points
           extends:
             - LemurBaseParams
+        content-type: application/json
       response:
         docs: LeMUR action items response
         type: LemurActionItemsResponse
@@ -239,7 +243,7 @@ service:
             transcript_ids:
               - 64nygnr62k-405c-4ae8-8a6b-d90b40ff3cce
             context: This is an interview about wildfires.
-            final_model: default
+            final_model: anthropic/claude-3-5-sonnet
             max_output_size: 3000
             temperature: 0
             answer_format: Bullet Points

--- a/fern/.definition/realtime.yml
+++ b/fern/.definition/realtime.yml
@@ -19,6 +19,7 @@ service:
               docs: The amount of time until the token expires in seconds
               validation:
                 min: 60
+        content-type: application/json
       response:
         docs: Temporary authentication token generated
         type: RealtimeTemporaryTokenResponse

--- a/fern/.definition/transcripts.yml
+++ b/fern/.definition/transcripts.yml
@@ -18,7 +18,7 @@ service:
         name: ListTranscriptParams
         query-parameters:
           limit:
-            type: optional<long>
+            type: optional<integer>
             docs: Maximum amount of transcripts to retrieve
           status:
             type: optional<TranscriptStatus>
@@ -104,6 +104,7 @@ service:
               docs: The URL of the audio or video file to transcribe.
           extends:
             - TranscriptOptionalParams
+        content-type: application/json
       response:
         docs: Transcript created and queued for processing
         type: Transcript
@@ -123,7 +124,8 @@ service:
             punctuate: true
             format_text: true
             disfluencies: false
-            dual_channel: true
+            multichannel: true
+            dual_channel: false
             webhook_url: https://your-webhook-url/path
             webhook_auth_header_name: webhook-secret
             webhook_auth_header_value: webhook-secret-value
@@ -257,76 +259,91 @@ service:
                   start: 250
                   end: 650
                   text: Smoke
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.99999
                   start: 730
                   end: 1022
                   text: from
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.99844
                   start: 1076
                   end: 1418
                   text: hundreds
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.84
                   start: 1434
                   end: 1614
                   text: of
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.89572
                   start: 1652
                   end: 2346
                   text: wildfires
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.99994
                   start: 2378
                   end: 2526
                   text: in
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.93953
                   start: 2548
                   end: 3130
                   text: Canada
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.999
                   start: 3210
                   end: 3454
                   text: is
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.74794
                   start: 3492
                   end: 3946
                   text: triggering
+                  channel: channel
                   speaker: speaker
                 - confidence: 1
                   start: 3978
                   end: 4174
                   text: air
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.88077
                   start: 4212
                   end: 4558
                   text: quality
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.94814
                   start: 4644
                   end: 5114
                   text: alerts
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.99726
                   start: 5162
                   end: 5466
                   text: throughout
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.79
                   start: 5498
                   end: 5694
                   text: the
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.89
                   start: 5732
                   end: 6382
                   text: US.
+                  channel: channel
                   speaker: speaker
               utterances:
                 - confidence: 0.9359033333333334
@@ -417,12 +434,15 @@ service:
                       end: 6382
                       text: US.
                       speaker: A
+                  channel: channel
                   speaker: A
               confidence: 0.9404651451800253
               audio_duration: 281
               punctuate: true
               format_text: true
               disfluencies: false
+              multichannel: false
+              audio_channels: 1
               dual_channel: false
               webhook_url: https://your-webhook-url.tld/path
               webhook_status_code: 200
@@ -706,6 +726,7 @@ service:
                   end: 6350
                   sentiment: NEGATIVE
                   confidence: 0.8181032538414001
+                  channel: channel
                   speaker: speaker
               entity_detection: true
               entities:
@@ -883,76 +904,91 @@ service:
                   start: 250
                   end: 650
                   text: Smoke
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.99999
                   start: 730
                   end: 1022
                   text: from
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.99844
                   start: 1076
                   end: 1418
                   text: hundreds
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.84
                   start: 1434
                   end: 1614
                   text: of
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.89572
                   start: 1652
                   end: 2346
                   text: wildfires
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.99994
                   start: 2378
                   end: 2526
                   text: in
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.93953
                   start: 2548
                   end: 3130
                   text: Canada
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.999
                   start: 3210
                   end: 3454
                   text: is
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.74794
                   start: 3492
                   end: 3946
                   text: triggering
+                  channel: channel
                   speaker: speaker
                 - confidence: 1
                   start: 3978
                   end: 4174
                   text: air
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.88077
                   start: 4212
                   end: 4558
                   text: quality
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.94814
                   start: 4644
                   end: 5114
                   text: alerts
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.99726
                   start: 5162
                   end: 5466
                   text: throughout
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.79
                   start: 5498
                   end: 5694
                   text: the
+                  channel: channel
                   speaker: speaker
                 - confidence: 0.89
                   start: 5732
                   end: 6382
                   text: US.
+                  channel: channel
                   speaker: speaker
               utterances:
                 - confidence: 0.9359033333333334
@@ -1043,12 +1079,15 @@ service:
                       end: 6382
                       text: US.
                       speaker: A
+                  channel: channel
                   speaker: A
               confidence: 0.9404651451800253
               audio_duration: 281
               punctuate: true
               format_text: true
               disfluencies: false
+              multichannel: false
+              audio_channels: 1
               dual_channel: false
               webhook_url: https://your-webhook-url.tld/path
               webhook_status_code: 200
@@ -1332,6 +1371,7 @@ service:
                   end: 6350
                   sentiment: NEGATIVE
                   confidence: 0.8181032538414001
+                  channel: channel
                   speaker: speaker
               entity_detection: true
               entities:
@@ -1519,6 +1559,7 @@ service:
                       start: 1498
                       end: 1646
                       text: of
+                  channel: channel
                   speaker: speaker
                 - text: >-
                     Skylines from Maine to Maryland to Minnesota are gray and
@@ -1551,6 +1592,7 @@ service:
                       start: 8730
                       end: 8926
                       text: to
+                  channel: channel
                   speaker: speaker
     getParagraphs:
       path: /v2/transcript/{transcript_id}/paragraphs
@@ -1837,6 +1879,13 @@ types:
           Transcribe Filler Words, like "umm", in your media file; can be true
           or false
         default: false
+      multichannel:
+        type: optional<boolean>
+        docs: >-
+          Enable
+          [Multichannel](https://www.assemblyai.com/docs/models/speech-recognition#multichannel-transcription)
+          transcription, can be true or false.
+        default: false
       dual_channel:
         type: optional<boolean>
         docs: >-
@@ -1844,6 +1893,7 @@ types:
           Channel](https://www.assemblyai.com/docs/models/speech-recognition#dual-channel-transcription)
           transcription, can be true or false.
         default: false
+        availability: deprecated
       webhook_url:
         type: optional<string>
         docs: >
@@ -2062,6 +2112,12 @@ types:
       words:
         docs: The words in the utterance.
         type: list<TranscriptWord>
+      channel:
+        type: optional<string>
+        docs: >-
+          The channel of this utterance. The left and right channels are
+          channels 1 and 2. Additional channels increment the channel number
+          sequentially.
       speaker:
         type: string
         docs: >-
@@ -2468,12 +2524,24 @@ types:
         docs: >-
           Transcribe Filler Words, like "umm", in your media file; can be true
           or false
+      multichannel:
+        type: optional<boolean>
+        docs: >-
+          Whether [Multichannel
+          transcription](https://www.assemblyai.com/docs/models/speech-recognition#multichannel-transcription)
+          was enabled in the transcription request, either true or false
+      audio_channels:
+        type: optional<integer>
+        docs: >-
+          The number of audio channels in the audio file. This is only present
+          when multichannel is enabled.
       dual_channel:
         type: optional<boolean>
         docs: >-
           Whether [Dual channel
           transcription](https://www.assemblyai.com/docs/models/speech-recognition#dual-channel-transcription)
           was enabled in the transcription request, either true or false
+        availability: deprecated
       webhook_url:
         type: optional<string>
         docs: >
@@ -2717,7 +2785,9 @@ types:
         docs: >-
           The status of the Content Moderation model. Either success, or
           unavailable in the rare case that the model failed.
-      results: list<ContentSafetyLabelResult>
+      results:
+        docs: An array of results for the Content Moderation model
+        type: list<ContentSafetyLabelResult>
       summary:
         type: map<string, double>
         docs: >-
@@ -2930,6 +3000,12 @@ types:
         validation:
           min: 0
           max: 1
+      channel:
+        type: optional<string>
+        docs: >-
+          The channel of this utterance. The left and right channels are
+          channels 1 and 2. Additional channels increment the channel number
+          sequentially.
       speaker:
         type: optional<string>
         docs: >-
@@ -2966,7 +3042,9 @@ types:
       text:
         type: string
         docs: The text in the transcript in which a detected topic occurs
-      labels: optional<list<TopicDetectionResultLabelsItem>>
+      labels:
+        type: optional<list<TopicDetectionResultLabelsItem>>
+        docs: An array of detected topics in the text
       timestamp: optional<Timestamp>
     source:
       openapi: ../openapi.yml
@@ -3068,31 +3146,58 @@ types:
     properties:
       confidence:
         type: double
+        docs: The confidence score for the transcript of this word
         validation:
           min: 0
           max: 1
-      start: integer
-      end: integer
-      text: string
+      start:
+        type: integer
+        docs: The starting time, in milliseconds, for the word
+      end:
+        type: integer
+        docs: The ending time, in milliseconds, for the word
+      text:
+        type: string
+        docs: The text of the word
+      channel:
+        type: optional<string>
+        docs: >-
+          The channel of the word. The left and right channels are channels 1
+          and 2. Additional channels increment the channel number sequentially.
       speaker:
         type: optional<string>
         docs: >-
-          The speaker of the sentence if [Speaker
+          The speaker of the word if [Speaker
           Diarization](https://www.assemblyai.com/docs/models/speaker-diarization)
           is enabled, else null
     source:
       openapi: ../openapi.yml
   TranscriptSentence:
     properties:
-      text: string
-      start: integer
-      end: integer
+      text:
+        type: string
+        docs: The transcript of the sentence
+      start:
+        type: integer
+        docs: The starting time, in milliseconds, for the sentence
+      end:
+        type: integer
+        docs: The ending time, in milliseconds, for the sentence
       confidence:
         type: double
+        docs: The confidence score for the transcript of this sentence
         validation:
           min: 0
           max: 1
-      words: list<TranscriptWord>
+      words:
+        docs: An array of words in the sentence
+        type: list<TranscriptWord>
+      channel:
+        type: optional<string>
+        docs: >-
+          The channel of the sentence. The left and right channels are channels
+          1 and 2. Additional channels increment the channel number
+          sequentially.
       speaker:
         type: optional<string>
         docs: >-
@@ -3105,43 +3210,64 @@ types:
     properties:
       id:
         type: string
+        docs: The unique identifier for the transcript
         validation:
           format: uuid
       confidence:
         type: double
+        docs: The confidence score for the transcript
         validation:
           min: 0
           max: 1
-      audio_duration: double
-      sentences: list<TranscriptSentence>
+      audio_duration:
+        type: double
+        docs: The duration of the audio file in seconds
+      sentences:
+        docs: An array of sentences in the transcript
+        type: list<TranscriptSentence>
     source:
       openapi: ../openapi.yml
   TranscriptParagraph:
     properties:
-      text: string
-      start: integer
-      end: integer
+      text:
+        type: string
+        docs: The transcript of the paragraph
+      start:
+        type: integer
+        docs: The starting time, in milliseconds, of the paragraph
+      end:
+        type: integer
+        docs: The ending time, in milliseconds, of the paragraph
       confidence:
         type: double
+        docs: The confidence score for the transcript of this paragraph
         validation:
           min: 0
           max: 1
-      words: list<TranscriptWord>
+      words:
+        docs: An array of words in the paragraph
+        type: list<TranscriptWord>
     source:
       openapi: ../openapi.yml
   ParagraphsResponse:
     properties:
       id:
         type: string
+        docs: The unique identifier of your transcript
         validation:
           format: uuid
       confidence:
         type: double
+        docs: The confidence score for the transcript
         validation:
           min: 0
           max: 1
-      audio_duration: double
-      paragraphs: list<TranscriptParagraph>
+      audio_duration:
+        type: double
+        docs: The duration of the audio file in seconds
+      paragraphs:
+        docs: An array of paragraphs in the transcript
+        type: list<TranscriptParagraph>
     source:
       openapi: ../openapi.yml
   PageDetails:
@@ -3174,13 +3300,24 @@ types:
     properties:
       id:
         type: string
+        docs: The unique identifier for the transcript
         validation:
           format: uuid
-      resource_url: string
-      status: TranscriptStatus
-      created: datetime
-      completed: optional<datetime>
-      audio_url: string
+      resource_url:
+        type: string
+        docs: The URL to retrieve the transcript
+      status:
+        type: TranscriptStatus
+        docs: The status of the transcript
+      created:
+        type: datetime
+        docs: The date and time the transcript was created
+      completed:
+        type: optional<datetime>
+        docs: The date and time the transcript was completed
+      audio_url:
+        type: string
+        docs: The URL to the audio file
       error:
         type: optional<string>
         docs: Error message of why the transcript failed
@@ -3191,8 +3328,12 @@ types:
       A list of transcripts. Transcripts are sorted from newest to oldest. The
       previous URL always points to a page with older transcripts.
     properties:
-      page_details: PageDetails
-      transcripts: list<TranscriptListItem>
+      page_details:
+        type: PageDetails
+        docs: Details of the transcript page
+      transcripts:
+        docs: An array of transcripts
+        type: list<TranscriptListItem>
     source:
       openapi: ../openapi.yml
   AudioIntelligenceModelStatus:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -4,6 +4,7 @@ instances:
 title: AssemblyAI | API Reference
 navigation:
   - api: API Reference
+    display-errors: true
     layout:
       - page: Overview
         path: ./pages/overview.mdx
@@ -30,6 +31,11 @@ navigation:
         contents:
           - realtime/createTemporaryToken
           - realtime/realtime
+    snippets:
+      # java: https://github.com/AssemblyAI/assemblyai-java-sdk
+      # csharp: https://github.com/AssemblyAI/assemblyai-csharp-sdk
+      ruby: https://github.com/AssemblyAI/assemblyai-ruby-sdk
+
 colors:
   accent-primary: "#df9844"
   background: "#09060F"

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "assemblyai",
-  "version": "0.42.8"
+  "version": "0.44.6"
 }

--- a/openapi.json
+++ b/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "AssemblyAI API",
     "description": "AssemblyAI API",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "termsOfService": "https://www.assemblyai.com/legal/terms-of-service",
     "contact": {
       "name": "API Support",
@@ -1654,11 +1654,18 @@
             "type": "boolean",
             "default": false
           },
+          "multichannel": {
+            "x-label": "Multichannel",
+            "description": "Enable [Multichannel](https://www.assemblyai.com/docs/models/speech-recognition#multichannel-transcription) transcription, can be true or false.",
+            "type": "boolean",
+            "default": false
+          },
           "dual_channel": {
             "x-label": "Dual channel",
             "description": "Enable [Dual Channel](https://www.assemblyai.com/docs/models/speech-recognition#dual-channel-transcription) transcription, can be true or false.",
             "type": "boolean",
-            "default": false
+            "default": false,
+            "deprecated": true
           },
           "webhook_url": {
             "x-label": "Webhook URL",
@@ -1864,7 +1871,8 @@
           "language_confidence_threshold": 0.7,
           "punctuate": true,
           "format_text": true,
-          "dual_channel": true,
+          "multichannel": true,
+          "dual_channel": false,
           "webhook_url": "https://your-webhook-url.tld/path",
           "webhook_auth_header_name": "webhook-secret",
           "webhook_auth_header_value": "webhook-secret-value",
@@ -1931,7 +1939,8 @@
           "audio_url": "https://assembly.ai/wildfires.mp3",
           "punctuate": true,
           "format_text": true,
-          "dual_channel": true,
+          "multichannel": true,
+          "dual_channel": false,
           "webhook_url": "https://your-webhook-url/path",
           "webhook_auth_header_name": "webhook-secret",
           "webhook_auth_header_value": "webhook-secret-value",
@@ -2092,6 +2101,11 @@
               "x-label": "Word",
               "$ref": "#/components/schemas/TranscriptWord"
             }
+          },
+          "channel": {
+            "x-label": "Channel",
+            "description": "The channel of this utterance. The left and right channels are channels 1 and 2. Additional channels increment the channel number sequentially.",
+            "type": ["string", "null"]
           },
           "speaker": {
             "x-label": "Speaker",
@@ -3204,10 +3218,21 @@
             "description": "Transcribe Filler Words, like \"umm\", in your media file; can be true or false",
             "type": ["boolean", "null"]
           },
+          "multichannel": {
+            "x-label": "Multichannel",
+            "description": "Whether [Multichannel transcription](https://www.assemblyai.com/docs/models/speech-recognition#multichannel-transcription) was enabled in the transcription request, either true or false",
+            "type": ["boolean", "null"]
+          },
+          "audio_channels": {
+            "x-label": "Audio channels",
+            "description": "The number of audio channels in the audio file. This is only present when multichannel is enabled.",
+            "type": "integer"
+          },
           "dual_channel": {
             "x-label": "Dual channel",
             "description": "Whether [Dual channel transcription](https://www.assemblyai.com/docs/models/speech-recognition#dual-channel-transcription) was enabled in the transcription request, either true or false",
-            "type": ["boolean", "null"]
+            "type": ["boolean", "null"],
+            "deprecated": true
           },
           "webhook_url": {
             "x-label": "Webhook URL",
@@ -3731,6 +3756,7 @@
           "audio_duration": 281,
           "punctuate": true,
           "format_text": true,
+          "multichannel": false,
           "dual_channel": false,
           "webhook_url": "https://your-webhook-url.tld/path",
           "webhook_status_code": 200,
@@ -4299,6 +4325,7 @@
           },
           "results": {
             "x-label": "Results",
+            "description": "An array of results for the Content Moderation model",
             "type": "array",
             "items": {
               "x-label": "Content Moderation label result",
@@ -4768,7 +4795,14 @@
         "x-fern-sdk-group-name": "transcripts",
         "type": "object",
         "additionalProperties": false,
-        "required": ["text", "start", "end", "sentiment", "confidence"],
+        "required": [
+          "text",
+          "start",
+          "end",
+          "sentiment",
+          "confidence",
+          "speaker"
+        ],
         "properties": {
           "text": {
             "x-label": "Text",
@@ -4797,6 +4831,11 @@
             "format": "double",
             "minimum": 0,
             "maximum": 1
+          },
+          "channel": {
+            "x-label": "Channel",
+            "description": "The channel of this utterance. The left and right channels are channels 1 and 2. Additional channels increment the channel number sequentially.",
+            "type": ["string", "null"]
           },
           "speaker": {
             "x-label": "Speaker",
@@ -4844,6 +4883,7 @@
           },
           "labels": {
             "x-label": "Labels",
+            "description": "An array of detected topics in the text",
             "type": "array",
             "items": {
               "x-label": "Label",
@@ -5328,10 +5368,11 @@
         "type": "object",
         "x-fern-sdk-group-name": "transcripts",
         "additionalProperties": false,
-        "required": ["confidence", "start", "end", "text"],
+        "required": ["confidence", "start", "end", "text", "speaker"],
         "properties": {
           "confidence": {
             "x-label": "Confidence",
+            "description": "The confidence score for the transcript of this word",
             "type": "number",
             "format": "double",
             "minimum": 0,
@@ -5339,19 +5380,27 @@
           },
           "start": {
             "x-label": "Start",
+            "description": "The starting time, in milliseconds, for the word",
             "type": "integer"
           },
           "end": {
             "x-label": "End",
+            "description": "The ending time, in milliseconds, for the word",
             "type": "integer"
           },
           "text": {
             "x-label": "Text",
+            "description": "The text of the word",
             "type": "string"
+          },
+          "channel": {
+            "x-label": "Channel",
+            "description": "The channel of the word. The left and right channels are channels 1 and 2. Additional channels increment the channel number sequentially.",
+            "type": ["string", "null"]
           },
           "speaker": {
             "x-label": "Speaker",
-            "description": "The speaker of the sentence if [Speaker Diarization](https://www.assemblyai.com/docs/models/speaker-diarization) is enabled, else null",
+            "description": "The speaker of the word if [Speaker Diarization](https://www.assemblyai.com/docs/models/speaker-diarization) is enabled, else null",
             "type": ["string", "null"]
           }
         },
@@ -5360,6 +5409,7 @@
           "start": 250,
           "end": 650,
           "confidence": 0.97465,
+          "channel": null,
           "speaker": null
         }
       },
@@ -5368,22 +5418,26 @@
         "type": "object",
         "x-fern-sdk-group-name": "transcripts",
         "additionalProperties": false,
-        "required": ["text", "start", "end", "confidence", "words"],
+        "required": ["text", "start", "end", "confidence", "words", "speaker"],
         "properties": {
           "text": {
             "x-label": "Text",
+            "description": "The transcript of the sentence",
             "type": "string"
           },
           "start": {
             "x-label": "Start",
+            "description": "The starting time, in milliseconds, for the sentence",
             "type": "integer"
           },
           "end": {
             "x-label": "End",
+            "description": "The ending time, in milliseconds, for the sentence",
             "type": "integer"
           },
           "confidence": {
             "x-label": "Confidence",
+            "description": "The confidence score for the transcript of this sentence",
             "type": "number",
             "format": "double",
             "minimum": 0,
@@ -5391,11 +5445,17 @@
           },
           "words": {
             "x-label": "Words",
+            "description": "An array of words in the sentence",
             "type": "array",
             "items": {
               "x-label": "Word",
               "$ref": "#/components/schemas/TranscriptWord"
             }
+          },
+          "channel": {
+            "x-label": "Channel",
+            "description": "The channel of the sentence. The left and right channels are channels 1 and 2. Additional channels increment the channel number sequentially.",
+            "type": ["string", "null"]
           },
           "speaker": {
             "x-label": "Speaker",
@@ -5450,11 +5510,13 @@
         "properties": {
           "id": {
             "x-label": "Transcript ID",
+            "description": "The unique identifier for the transcript",
             "type": "string",
             "format": "uuid"
           },
           "confidence": {
             "x-label": "Confidence",
+            "description": "The confidence score for the transcript",
             "type": "number",
             "format": "double",
             "minimum": 0,
@@ -5462,10 +5524,12 @@
           },
           "audio_duration": {
             "x-label": "Audio duration",
+            "description": "The duration of the audio file in seconds",
             "type": "number"
           },
           "sentences": {
             "x-label": "Sentences",
+            "description": "An array of sentences in the transcript",
             "type": "array",
             "items": {
               "x-label": "Sentence",
@@ -5578,18 +5642,22 @@
         "properties": {
           "text": {
             "x-label": "Text",
+            "description": "The transcript of the paragraph",
             "type": "string"
           },
           "start": {
             "x-label": "Start",
+            "description": "The starting time, in milliseconds, of the paragraph",
             "type": "integer"
           },
           "end": {
             "x-label": "End",
+            "description": "The ending time, in milliseconds, of the paragraph",
             "type": "integer"
           },
           "confidence": {
             "x-label": "Confidence",
+            "description": "The confidence score for the transcript of this paragraph",
             "type": "number",
             "format": "double",
             "minimum": 0,
@@ -5597,6 +5665,7 @@
           },
           "words": {
             "x-label": "Words",
+            "description": "An array of words in the paragraph",
             "type": "array",
             "items": {
               "x-label": "Word",
@@ -5650,11 +5719,13 @@
         "properties": {
           "id": {
             "x-label": "Transcript ID",
+            "description": "The unique identifier of your transcript",
             "type": "string",
             "format": "uuid"
           },
           "confidence": {
             "x-label": "Confidence",
+            "description": "The confidence score for the transcript",
             "type": "number",
             "format": "double",
             "minimum": 0,
@@ -5662,10 +5733,12 @@
           },
           "audio_duration": {
             "x-label": "Audio duration",
+            "description": "The duration of the audio file in seconds",
             "type": "number"
           },
           "paragraphs": {
             "x-label": "Paragraphs",
+            "description": "An array of paragraphs in the transcript",
             "type": "array",
             "items": {
               "x-label": "Paragraph",
@@ -5808,7 +5881,6 @@
             "x-label": "Limit",
             "description": "Maximum amount of transcripts to retrieve",
             "type": "integer",
-            "format": "int64",
             "minimum": 1,
             "maximum": 200,
             "default": 10
@@ -5869,20 +5941,24 @@
         "properties": {
           "id": {
             "x-label": "ID",
+            "description": "The unique identifier for the transcript",
             "type": "string",
             "format": "uuid"
           },
           "resource_url": {
             "x-label": "Resource URL",
+            "description": "The URL to retrieve the transcript",
             "type": "string",
             "format": "url"
           },
           "status": {
             "x-label": "Status",
+            "description": "The status of the transcript",
             "$ref": "#/components/schemas/TranscriptStatus"
           },
           "created": {
             "x-label": "Created",
+            "description": "The date and time the transcript was created",
             "type": "string",
             "pattern": "^(?:(\\d{4}-\\d{2}-\\d{2})T(\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?))$",
             "x-fern-type": "datetime",
@@ -5890,6 +5966,7 @@
           },
           "completed": {
             "x-label": "Completed",
+            "description": "The date and time the transcript was completed",
             "type": ["string", "null"],
             "pattern": "^(?:(\\d{4}-\\d{2}-\\d{2})T(\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?))$",
             "x-fern-type": "optional<datetime>",
@@ -5897,6 +5974,7 @@
           },
           "audio_url": {
             "x-label": "Audio URL",
+            "description": "The URL to the audio file",
             "type": "string",
             "format": "url"
           },
@@ -5926,10 +6004,12 @@
         "properties": {
           "page_details": {
             "x-label": "Page details",
+            "description": "Details of the transcript page",
             "$ref": "#/components/schemas/PageDetails"
           },
           "transcripts": {
             "x-label": "Transcripts",
+            "description": "An array of transcripts",
             "type": "array",
             "items": {
               "x-label": "Transcript list item",
@@ -6337,7 +6417,7 @@
             "7c3acd18-df4d-4432-88f5-1e89f8827eea"
           ],
           "context": "This is an interview about wildfires.",
-          "final_model": "default",
+          "final_model": "anthropic/claude-3-5-sonnet",
           "temperature": 0,
           "max_output_size": 3000
         }
@@ -6367,7 +6447,7 @@
           "transcript_ids": ["64nygnr62k-405c-4ae8-8a6b-d90b40ff3cce"],
           "prompt": "List all the locations affected by wildfires.",
           "context": "This is an interview about wildfires.",
-          "final_model": "default",
+          "final_model": "anthropic/claude-3-5-sonnet",
           "temperature": 0,
           "max_output_size": 3000
         }
@@ -6395,7 +6475,7 @@
         "example": {
           "transcript_ids": ["47b95ba5-8889-44d8-bc80-5de38306e582"],
           "context": "This is an interview about wildfires.",
-          "final_model": "default",
+          "final_model": "anthropic/claude-3-5-sonnet",
           "temperature": 0,
           "max_output_size": 3000
         }
@@ -6439,7 +6519,7 @@
               "answer_options": ["yes", "no"]
             }
           ],
-          "final_model": "default",
+          "final_model": "anthropic/claude-3-5-sonnet",
           "temperature": 0,
           "max_output_size": 3000
         }
@@ -6514,7 +6594,7 @@
           "transcript_ids": ["64nygnr62k-405c-4ae8-8a6b-d90b40ff3cce"],
           "context": "This is an interview about wildfires.",
           "answer_format": "Bullet Points",
-          "final_model": "default",
+          "final_model": "anthropic/claude-3-5-sonnet",
           "temperature": 0,
           "max_output_size": 3000
         }
@@ -6674,7 +6754,7 @@
       "Error": {
         "x-label": "Error",
         "type": "object",
-        "additionalProperties": false,
+        "additionalProperties": true,
         "required": ["error"],
         "properties": {
           "error": {
@@ -6718,6 +6798,7 @@
           "audio_duration": 390,
           "punctuate": null,
           "format_text": null,
+          "multichannel": false,
           "dual_channel": null,
           "webhook_url": "http://deleted_by_user",
           "webhook_status_code": null,
@@ -6773,6 +6854,9 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "error": "This is a sample error message"
             }
           }
         }
@@ -6784,6 +6868,9 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "error": "Authentication error, API token missing/invalid"
             }
           }
         }
@@ -6795,6 +6882,9 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "error": "Not found"
             }
           }
         }
@@ -6806,6 +6896,9 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "error": "Too Many Requests"
             }
           }
         },
@@ -6825,6 +6918,9 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "error": "Internal Server Error"
             }
           }
         }

--- a/openapi.yml
+++ b/openapi.yml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
   title: AssemblyAI API
   description: AssemblyAI API
-  version: 1.3.3
+  version: 1.3.4
   termsOfService: https://www.assemblyai.com/legal/terms-of-service
   contact:
     name: API Support
@@ -1256,11 +1256,18 @@ components:
           type: boolean
           default: false
 
+        multichannel:
+          x-label: Multichannel
+          description: Enable [Multichannel](https://www.assemblyai.com/docs/models/speech-recognition#multichannel-transcription) transcription, can be true or false.
+          type: boolean
+          default: false
+
         dual_channel:
           x-label: Dual channel
           description: Enable [Dual Channel](https://www.assemblyai.com/docs/models/speech-recognition#dual-channel-transcription) transcription, can be true or false.
           type: boolean
           default: false
+          deprecated: true
 
         webhook_url:
           x-label: Webhook URL
@@ -1461,7 +1468,8 @@ components:
           language_confidence_threshold: 0.7,
           punctuate: true,
           format_text: true,
-          dual_channel: true,
+          multichannel: true,
+          dual_channel: false,
           webhook_url: "https://your-webhook-url.tld/path",
           webhook_auth_header_name: "webhook-secret",
           webhook_auth_header_value: "webhook-secret-value",
@@ -1520,7 +1528,8 @@ components:
           audio_url: "https://assembly.ai/wildfires.mp3",
           punctuate: true,
           format_text: true,
-          dual_channel: true,
+          multichannel: true,
+          dual_channel: false,
           webhook_url: "https://your-webhook-url/path",
           webhook_auth_header_name: "webhook-secret",
           webhook_auth_header_value: "webhook-secret-value",
@@ -1664,6 +1673,10 @@ components:
           items:
             x-label: Word
             $ref: "#/components/schemas/TranscriptWord"
+        channel:
+          x-label: Channel
+          description: The channel of this utterance. The left and right channels are channels 1 and 2. Additional channels increment the channel number sequentially.
+          type: [string, "null"]
         speaker:
           x-label: Speaker
           description: The speaker of this utterance, where each speaker is assigned a sequential capital letter - e.g. "A" for Speaker A, "B" for Speaker B, etc.
@@ -2602,10 +2615,21 @@ components:
           description: Transcribe Filler Words, like "umm", in your media file; can be true or false
           type: [boolean, "null"]
 
+        multichannel:
+          x-label: Multichannel
+          description: Whether [Multichannel transcription](https://www.assemblyai.com/docs/models/speech-recognition#multichannel-transcription) was enabled in the transcription request, either true or false
+          type: [boolean, "null"]
+
+        audio_channels:
+          x-label: Audio channels
+          description: The number of audio channels in the audio file. This is only present when multichannel is enabled.
+          type: integer
+
         dual_channel:
           x-label: Dual channel
           description: Whether [Dual channel transcription](https://www.assemblyai.com/docs/models/speech-recognition#dual-channel-transcription) was enabled in the transcription request, either true or false
           type: [boolean, "null"]
+          deprecated: true
 
         webhook_url:
           x-label: Webhook URL
@@ -3127,6 +3151,7 @@ components:
           audio_duration: 281,
           punctuate: true,
           format_text: true,
+          multichannel: false,
           dual_channel: false,
           webhook_url: "https://your-webhook-url.tld/path",
           webhook_status_code: 200,
@@ -3623,6 +3648,7 @@ components:
           $ref: "#/components/schemas/AudioIntelligenceModelStatus"
         results:
           x-label: Results
+          description: An array of results for the Content Moderation model
           type: array
           items:
             x-label: Content Moderation label result
@@ -4036,6 +4062,7 @@ components:
         - end
         - sentiment
         - confidence
+        - speaker
       properties:
         text:
           x-label: Text
@@ -4060,6 +4087,10 @@ components:
           format: double
           minimum: 0
           maximum: 1
+        channel:
+          x-label: Channel
+          description: The channel of this utterance. The left and right channels are channels 1 and 2. Additional channels increment the channel number sequentially.
+          type: [string, "null"]
         speaker:
           x-label: Speaker
           description: The speaker of the sentence if [Speaker Diarization](https://www.assemblyai.com/docs/models/speaker-diarization) is enabled, else null
@@ -4104,6 +4135,7 @@ components:
           type: string
         labels:
           x-label: Labels
+          description: An array of detected topics in the text
           type: array
           items:
             x-label: Label
@@ -4486,25 +4518,34 @@ components:
         - start
         - end
         - text
+        - speaker
       properties:
         confidence:
           x-label: Confidence
+          description: The confidence score for the transcript of this word
           type: number
           format: double
           minimum: 0
           maximum: 1
         start:
           x-label: Start
+          description: The starting time, in milliseconds, for the word
           type: integer
         end:
           x-label: End
+          description: The ending time, in milliseconds, for the word
           type: integer
         text:
           x-label: Text
+          description: The text of the word
           type: string
+        channel:
+          x-label: Channel
+          description: The channel of the word. The left and right channels are channels 1 and 2. Additional channels increment the channel number sequentially.
+          type: [string, "null"]
         speaker:
           x-label: Speaker
-          description: The speaker of the sentence if [Speaker Diarization](https://www.assemblyai.com/docs/models/speaker-diarization) is enabled, else null
+          description: The speaker of the word if [Speaker Diarization](https://www.assemblyai.com/docs/models/speaker-diarization) is enabled, else null
           type: [string, "null"]
       example:
         {
@@ -4512,6 +4553,7 @@ components:
           start: 250,
           end: 650,
           confidence: 0.97465,
+          channel: null,
           speaker: null,
         }
 
@@ -4526,28 +4568,38 @@ components:
         - end
         - confidence
         - words
+        - speaker
       properties:
         text:
           x-label: Text
+          description: The transcript of the sentence
           type: string
         start:
           x-label: Start
+          description: The starting time, in milliseconds, for the sentence
           type: integer
         end:
           x-label: End
+          description: The ending time, in milliseconds, for the sentence
           type: integer
         confidence:
           x-label: Confidence
+          description: The confidence score for the transcript of this sentence
           type: number
           format: double
           minimum: 0
           maximum: 1
         words:
           x-label: Words
+          description: An array of words in the sentence
           type: array
           items:
             x-label: Word
             $ref: "#/components/schemas/TranscriptWord"
+        channel:
+          x-label: Channel
+          description: The channel of the sentence. The left and right channels are channels 1 and 2. Additional channels increment the channel number sequentially.
+          type: [string, "null"]
         speaker:
           x-label: Speaker
           description: The speaker of the sentence if [Speaker Diarization](https://www.assemblyai.com/docs/models/speaker-diarization) is enabled, else null
@@ -4605,19 +4657,23 @@ components:
       properties:
         id:
           x-label: Transcript ID
+          description: The unique identifier for the transcript
           type: string
           format: uuid
         confidence:
           x-label: Confidence
+          description: The confidence score for the transcript
           type: number
           format: double
           minimum: 0
           maximum: 1
         audio_duration:
           x-label: Audio duration
+          description: The duration of the audio file in seconds
           type: number
         sentences:
           x-label: Sentences
+          description: An array of sentences in the transcript
           type: array
           items:
             x-label: Sentence
@@ -4736,21 +4792,26 @@ components:
       properties:
         text:
           x-label: Text
+          description: The transcript of the paragraph
           type: string
         start:
           x-label: Start
+          description: The starting time, in milliseconds, of the paragraph
           type: integer
         end:
           x-label: End
+          description: The ending time, in milliseconds, of the paragraph
           type: integer
         confidence:
           x-label: Confidence
+          description: The confidence score for the transcript of this paragraph
           type: number
           format: double
           minimum: 0
           maximum: 1
         words:
           x-label: Words
+          description: An array of words in the paragraph
           type: array
           items:
             x-label: Word
@@ -4807,19 +4868,23 @@ components:
       properties:
         id:
           x-label: Transcript ID
+          description: The unique identifier of your transcript
           type: string
           format: uuid
         confidence:
           x-label: Confidence
+          description: The confidence score for the transcript
           type: number
           format: double
           minimum: 0
           maximum: 1
         audio_duration:
           x-label: Audio duration
+          description: The duration of the audio file in seconds
           type: number
         paragraphs:
           x-label: Paragraphs
+          description: An array of paragraphs in the transcript
           type: array
           items:
             x-label: Paragraph
@@ -4958,7 +5023,6 @@ components:
           x-label: Limit
           description: Maximum amount of transcripts to retrieve
           type: integer
-          format: int64
           minimum: 1
           maximum: 200
           default: 10
@@ -5012,29 +5076,35 @@ components:
       properties:
         id:
           x-label: ID
+          description: The unique identifier for the transcript
           type: string
           format: uuid
         resource_url:
           x-label: Resource URL
+          description: The URL to retrieve the transcript
           type: string
           format: url
         status:
           x-label: Status
+          description: The status of the transcript
           $ref: "#/components/schemas/TranscriptStatus"
         created:
           x-label: Created
+          description: The date and time the transcript was created
           type: string
           pattern: '^(?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))$'
           x-fern-type: datetime
           x-ts-type: Date
         completed:
           x-label: Completed
+          description: The date and time the transcript was completed
           type: [string, "null"]
           pattern: '^(?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))$'
           x-fern-type: optional<datetime>
           x-ts-type: Date | null
         audio_url:
           x-label: Audio URL
+          description: The URL to the audio file
           type: string
           format: url
         error:
@@ -5064,9 +5134,11 @@ components:
       properties:
         page_details:
           x-label: Page details
+          description: Details of the transcript page
           $ref: "#/components/schemas/PageDetails"
         transcripts:
           x-label: Transcripts
+          description: An array of transcripts
           type: array
           items:
             x-label: Transcript list item
@@ -5448,7 +5520,7 @@ components:
               "7c3acd18-df4d-4432-88f5-1e89f8827eea",
             ],
           context: "This is an interview about wildfires.",
-          final_model: "default",
+          final_model: "anthropic/claude-3-5-sonnet",
           temperature: 0,
           max_output_size: 3000,
         }
@@ -5472,7 +5544,7 @@ components:
           transcript_ids: ["64nygnr62k-405c-4ae8-8a6b-d90b40ff3cce"],
           prompt: "List all the locations affected by wildfires.",
           context: "This is an interview about wildfires.",
-          final_model: "default",
+          final_model: "anthropic/claude-3-5-sonnet",
           temperature: 0,
           max_output_size: 3000,
         }
@@ -5495,7 +5567,7 @@ components:
         {
           transcript_ids: ["47b95ba5-8889-44d8-bc80-5de38306e582"],
           context: "This is an interview about wildfires.",
-          final_model: "default",
+          final_model: "anthropic/claude-3-5-sonnet",
           temperature: 0,
           max_output_size: 3000,
         }
@@ -5533,7 +5605,7 @@ components:
                 answer_options: ["yes", "no"],
               },
             ],
-          final_model: "default",
+          final_model: "anthropic/claude-3-5-sonnet",
           temperature: 0,
           max_output_size: 3000,
         }
@@ -5596,7 +5668,7 @@ components:
           transcript_ids: ["64nygnr62k-405c-4ae8-8a6b-d90b40ff3cce"],
           context: "This is an interview about wildfires.",
           answer_format: "Bullet Points",
-          final_model: "default",
+          final_model: "anthropic/claude-3-5-sonnet",
           temperature: 0,
           max_output_size: 3000,
         }
@@ -5734,7 +5806,7 @@ components:
     Error:
       x-label: Error
       type: object
-      additionalProperties: false
+      additionalProperties: true
       required: [error]
       properties:
         error:
@@ -5790,6 +5862,7 @@ components:
           audio_duration: 390,
           punctuate: null,
           format_text: null,
+          multichannel: false,
           dual_channel: null,
           webhook_url: "http://deleted_by_user",
           webhook_status_code: null,
@@ -5844,6 +5917,7 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+          example: { "error": "This is a sample error message" }
     Unauthorized:
       x-label: Unauthorized
       description: Unauthorized
@@ -5851,6 +5925,8 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+          example:
+            { "error": "Authentication error, API token missing/invalid" }
     NotFound:
       x-label: Not found
       description: Not found
@@ -5858,6 +5934,7 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+          example: { "error": "Not found" }
     TooManyRequests:
       x-label: Too many requests
       description: Too many requests
@@ -5865,6 +5942,7 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+          example: { "error": "Too Many Requests" }
       headers:
         Retry-After:
           description: The number of seconds to wait before retrying the request
@@ -5877,6 +5955,7 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+          example: { "error": "Internal Server Error" }
     ServiceUnavailable:
       x-label: Service unavailable
       description: Service unavailable

--- a/package.json
+++ b/package.json
@@ -13,15 +13,18 @@
     "precommit": "pnpm lint && pnpm generate:fern-definition && pnpm to-json && pnpm format"
   },
   "devDependencies": {
-    "@stoplight/spectral-cli": "^6.11.1",
-    "fern-api": "^0.30.10",
-    "js-yaml": "^4.1.0",
-    "prettier": "^3.3.2"
+    "@stoplight/spectral-cli": "^6.13.1",
+    "fern-api": "^0.44.6",
+    "prettier": "^3.3.3"
   },
   "pnpm": {
     "overrides": {
       "undici@<5.28.4": ">=5.28.4",
-      "braces@<3.0.3": ">=3.0.3"
+      "braces@<3.0.3": ">=3.0.3",
+      "micromatch@<4.0.8": ">=4.0.8",
+      "rollup@<2.79.2": ">=2.79.2",
+      "rollup@>=4.0.0 <4.22.4": ">=4.22.4"
     }
-  }
+  },
+  "packageManager": "pnpm@8.15.9+sha256.daa27a0b541bc635323ff96c2ded995467ff9fe6d69ff67021558aa9ad9dcc36"
 }


### PR DESCRIPTION
- Add an example for specific HTTP error responses
- Add `multichannel` property to `TranscriptParams` and `TranscriptOptionalParams` schemas
- Add `multichannel` and `audio_channels` properties to `Transcript` schema
- Add `channel` property to `TranscriptUtterance`, `TranscriptSentence`, `TranscriptWord`, and `SentimentAnalysisResult`
- Deprecate the `dual_channel` property on the `TranscriptParams`, `TranscriptOptionalParams`, and `Transcript` schema.
- Update LeMUR examples to use latest LeMUR model instead of deprecated default model.
- Make `Error` schema have additional properties
- Update dependencies