### PR TITLE
revert overview page layout change

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -3,11 +3,11 @@ instances:
     custom-domain: fern.assemblyai.com/docs
 title: AssemblyAI | API Reference
 navigation:
-  - page: Overview
-    path: ./pages/overview.mdx
   - api: API Reference
     display-errors: true
     layout:
+      - page: Overview
+        path: ./pages/overview.mdx
       - files
       - transcripts:
           - submit


### PR DESCRIPTION
leads to a broken link assemblyai.com/docs/overview