### PR TITLE
add EU endpoint to openapi.yml

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -12,7 +12,11 @@ info:
 
 servers:
   - url: https://api.assemblyai.com
-    description: AssemblyAI API
+    description: AssemblyAI API (US Region)
+    x-fern-server-name: Default
+  - url: https://eu.api.assemblyai.com
+    description: AssemblyAI API (EU Region)
+    x-fern-server-name: EU
 
 tags:
   - name: transcript


### PR DESCRIPTION
This adds the EU endpoint to our API reference but it also adds a bug to our API reference where the endpoint also shows up for LeMUR and Streaming.