### PR TITLE
Add lemur tips to audio intelligence pages

### DIFF
--- a/fern/pages/03-audio-intelligence/auto-chapters.mdx
+++ b/fern/pages/03-audio-intelligence/auto-chapters.mdx
@@ -219,7 +219,9 @@ end
 29610-280340: High particulate matter in wildfire smoke can lead to serious health problems
 ```
 
-
+<Tip title="Auto Chapters Using LeMUR">
+Check out this cookbook [Creating Chapter Summaries](https://github.com/AssemblyAI/cookbook/blob/master/lemur/input-text-chapters.ipynb) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
+</Tip>
 
 
 

--- a/fern/pages/03-audio-intelligence/sentiment-analysis.mdx
+++ b/fern/pages/03-audio-intelligence/sentiment-analysis.mdx
@@ -229,7 +229,9 @@ SentimentType.negative
 Timestamp: 250 - 6350
 ...
 ```
-
+<Tip title="Sentiment Analysis Using LeMUR">
+Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](https://github.com/AssemblyAI/cookbook/blob/master/lemur/call-sentiment-analysis.ipynb) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
+</Tip>
 
 
 

--- a/fern/pages/03-audio-intelligence/summarization.mdx
+++ b/fern/pages/03-audio-intelligence/summarization.mdx
@@ -225,7 +225,7 @@ puts transcript.summary
 - Air pollution levels in Baltimore are considered unhealthy. Exposure to high levels can lead to a host of health problems. With climate change, we are seeing more wildfires. Will we be seeing more of these kinds of wide ranging air quality consequences?
 ```
 
-<Tip title="Custom summaries using LeMUR">
+<Tip title="Custom Summaries Using LeMUR">
 If you want more control of the output format, see how to generate a [Custom summary using LeMUR](/docs/lemur/summarize-your-audio-data).
 </Tip>
 

--- a/fern/pages/03-audio-intelligence/topic-detection.mdx
+++ b/fern/pages/03-audio-intelligence/topic-detection.mdx
@@ -292,7 +292,9 @@ Audio is 93.78% relevant to Home&Garden>IndoorEnvironmentalQuality
 ...
 ```
 
-
+<Tip title="Topic Detection Using LeMUR">
+Check out this cookbook [Custom Topic Tags](https://github.com/AssemblyAI/cookbook/blob/master/lemur/custom-topic-tags.ipynb) for an example of how to leverage LeMUR for custom topic detection.
+</Tip>
 
 
 


### PR DESCRIPTION
I've added Tip Boxes that include links to relevant lemur cookbooks for these audio intelligence features: topic detection, auto chapters, and sentiment analysis. 