### PR TITLE
fix(kapa): add stable project image

### DIFF
--- a/fern/kapa.js
+++ b/fern/kapa.js
@@ -12,8 +12,7 @@ function insertKapa() {
   script.setAttribute("data-website-id", "42353092-36d7-42bd-a213-6fd7af0de0cd");
   script.setAttribute("data-project-name", "AssemblyAI");
   script.setAttribute("data-project-color", "#2C4BD4");
-  // TODO: fix this link
-  script.setAttribute("data-project-logo", "https://devrel.sandbox.assemblyai.xyz/docs/img/logo-blue400x400.jpeg");
+  script.setAttribute("data-project-logo", "https://www.assemblyai.com/static/images/logo-blue400x400.jpeg");
   script.setAttribute("data-modal-override-open-id-search", "fern-search-button");
   script.setAttribute("data-search-include-source-names", '["Pylon FAQ", "Documentation"]');
   document.head.appendChild(script);


### PR DESCRIPTION
Use Kapa stable project image. 
There's a [PR](https://github.com/AssemblyAI/web/pull/2658) to put the project logo on https://www.assemblyai.com/static/images/logo-blue400x400.jpeg

There's a risk with using https://devrel.sandbox.assemblyai.xyz/docs/img/logo-blue400x400.jpeg whereby a new deployment to that branch will render the image route invalid since the `/docs/*` path segment is no longer managed by us.

### NOTE
This should not be deployed before the referenced pr hits production.
