### PR TITLE
Fix sidebar link to TypeScript SDK

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -106,7 +106,7 @@ navigation:
               - link: Python
                 href: https://github.com/AssemblyAI/assemblyai-python-sdk
               - link: TypeScript
-                href: https://github.com/AssemblyAI/assemblyai-typescript-sdk
+                href: https://github.com/AssemblyAI/assemblyai-node-sdk
               - link: Go
                 href: https://github.com/AssemblyAI/assemblyai-go-sdk
               - link: Java


### PR DESCRIPTION
Fixes the sidebar link to the TypeScript SDK (should be `assemblyai-node-sdk`).

All other links to the TypeScript SDK use the correct URL, so no other fixes are required. 