### PR TITLE
Remove open callback reference from TypeScript streaming example

### DIFF
--- a/fern/pages/01-getting-started/transcribe-streaming-audio-from-a-microphone/typescript.mdx
+++ b/fern/pages/01-getting-started/transcribe-streaming-audio-from-a-microphone/typescript.mdx
@@ -286,7 +286,7 @@ The `SoxRecording` class lets you interact with SoX more easily.
 </Step>
 <Step>
 
-In the `on("open")` callback, create a new microphone stream. The `sampleRate` needs to be the same value as the real-time service settings.
+Create a new microphone stream. The `sampleRate` needs to be the same value as the real-time service settings.
 
 ```typescript
 const recording = new SoxRecording({


### PR DESCRIPTION
The callback/listener for the `open` event doesn't actually create the microphone stream. In the [code example](https://www.assemblyai.com/docs/getting-started/transcribe-streaming-audio-from-a-microphone/typescript#before-you-begin), the stream is created later in the body of the main `start` function.

Relevant code from the example:
```ts
// line 16
transcriber.on('open', ({ sessionId }) => {
  console.log(`Session opened with ID: ${sessionId}`)
})

...

// line 40
console.log('Connecting to real-time transcript service')
await transcriber.connect()

console.log('Starting recording')
const recording = new SoxRecording({
  channels: 1,
  sampleRate: SAMPLE_RATE,
  audioType: 'wav' // Linear PCM
})

recording.stream().pipeTo(transcriber.stream())
```

[Step](https://www.assemblyai.com/docs/getting-started/transcribe-streaming-audio-from-a-microphone/typescript#step-3-1) being edited by this PR. [Here](https://www.assemblyai.com/docs/getting-started/transcribe-streaming-audio-from-a-microphone/python#step-1-3) is the same step in the Python SDK for reference.