### PR TITLE
fix: API reference updates

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -5685,7 +5685,6 @@ components:
         - anthropic/claude-3-opus
         - anthropic/claude-3-haiku
         - anthropic/claude-3-sonnet
-        - assemblyai/mistral-7b
       x-fern-enum:
         anthropic/claude-3-5-sonnet:
           description: >

--- a/openapi.yml
+++ b/openapi.yml
@@ -1452,6 +1452,7 @@ components:
           description: Enable custom topics, either true or false
           type: boolean
           default: false
+          deprecated: true
 
         topics:
           x-label: Custom topics


### PR DESCRIPTION
- Tag the custom_topics parameter as "Depreciated" for the Transcripts endpoints
- Remove assemblyai/mistral-7b as an option for final_model for all LeMUR requests