### PR TITLE
feat: scroll to highlighted lines in code blocks

### DIFF
--- a/cookbook-master/core-transcription/detecting-low-confidence-words.md
+++ b/cookbook-master/core-transcription/detecting-low-confidence-words.md
@@ -23,7 +23,7 @@ const client = new AssemblyAI({
 Next create the transcript with your audio file, either via local audio file or URL (AssemblyAI's servers need to be able to access the URL, make sure the URL links to a downloadable file).
 
 ```javascript
-const transcript = await client.transcripts.create({
+const transcript = await client.transcripts.transcribe({
   audio_url: './sample.mp4',
 })
 ```

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -8,6 +8,8 @@ js:
     strategy: beforeInteractive
   - path: ./pre-recorded-audio-redirect.js
     strategy: beforeInteractive
+  - path: ./scroll-highlighted-lines.js
+    strategy: beforeInteractive
 announcement:
   message: '🗝️ Multiple API keys and Projects are now available 🎉 (<a href="/docs/deployment/account-management" target="_blank" style="color: white;">Learn more</a>)'
 title: AssemblyAI | Documentation

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -9,7 +9,7 @@ js:
   - path: ./pre-recorded-audio-redirect.js
     strategy: beforeInteractive
   - path: ./scroll-highlighted-lines.js
-    strategy: beforeInteractive
+    strategy: afterInteractive
 announcement:
   message: '🗝️ Multiple API keys and Projects are now available 🎉 (<a href="/docs/deployment/account-management" target="_blank" style="color: white;">Learn more</a>)'
 title: AssemblyAI | Documentation

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-language-detection.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-language-detection.mdx
@@ -8,7 +8,7 @@ To reliably identify the dominant language, the file must contain **at least 50 
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={8,13} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -24,7 +24,7 @@ print(transcript.text)
 print(transcript.json_response["language_code"])
 ```
 
-```python title="Python" highlight={19} maxLines=10
+```python title="Python" highlight={19} maxLines=15
 import requests
 import time
 
@@ -69,7 +69,7 @@ while True:
 
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={13} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -95,7 +95,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={19} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -142,7 +142,7 @@ while (true) {
 
 ```
 
-```csharp title="C#" highlight={39} maxLines=15
+```csharp title="C#" highlight={39}  maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -229,7 +229,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={23} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -295,7 +295,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={30} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -380,7 +380,7 @@ If language detection is enabled, the API returns a confidence score for the det
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={8,13} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -396,7 +396,7 @@ print(transcript.text)
 print(transcript.json_response["language_confidence"])
 ```
 
-```python title="Python"
+```python title="Python" highlight={33} maxLines=15
 import requests
 import time
 
@@ -441,7 +441,7 @@ while True:
 
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={20} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -467,7 +467,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={36} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -514,7 +514,7 @@ while (true) {
 
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={83} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -601,7 +601,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={55} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -667,7 +667,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={62} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -749,7 +749,7 @@ if the language confidence is below this threshold. Valid values are in the rang
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={8,13} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -763,11 +763,9 @@ transcript = aai.Transcriber(config=config).transcribe(audio_file)
 
 if transcript.status == "error":
   raise RuntimeError(f"Transcription failed: {transcript.error}")
-
-print(transcript.text)
 ```
 
-```python title="Python"
+```python title="Python" highlight={20} maxLines=15
 import requests
 import time
 
@@ -812,7 +810,7 @@ while True:
 
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={14} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -843,7 +841,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={20} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -891,7 +889,7 @@ while (true) {
 
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={39} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -978,7 +976,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={24} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -1045,7 +1043,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={31} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-language-detection.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-language-detection.mdx
@@ -24,7 +24,7 @@ print(transcript.text)
 print(transcript.json_response["language_code"])
 ```
 
-```python title="Python"
+```python title="Python" highlight={19}
 import requests
 import time
 
@@ -142,7 +142,7 @@ while (true) {
 
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={39}
 using System;
 using System.IO;
 using System.Net.Http;

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-language-detection.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-language-detection.mdx
@@ -24,7 +24,7 @@ print(transcript.text)
 print(transcript.json_response["language_code"])
 ```
 
-```python title="Python" highlight={19}
+```python title="Python" highlight={19} maxLines=10
 import requests
 import time
 
@@ -142,7 +142,7 @@ while (true) {
 
 ```
 
-```csharp title="C#" highlight={39}
+```csharp title="C#" highlight={39} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-punctuation-and-casing.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-punctuation-and-casing.mdx
@@ -8,7 +8,7 @@ You can disable this behavior by setting `punctuate` and `format_text` to `False
 
 <Tabs>
   <Tab language="python-sdk" title="Python SDK" default>
-```python maxLines=15
+```python highlight={8} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -27,7 +27,7 @@ print(transcript.text)
 ```
   </Tab>
   <Tab language="python" title="Python">
-```python maxLines=15
+```python highlight={19-20} maxLines=15
 import requests
 import time
 
@@ -72,7 +72,7 @@ while True:
 ```
   </Tab>
   <Tab language="typescript-sdk" title="TypeScript SDK" default>
-```ts maxLines=15
+```ts highlight={13-14} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -99,7 +99,7 @@ run()
 ```
   </Tab>
   <Tab language="typescript" title="TypeScript">
-```ts maxLines=15
+```ts highlight={19-20} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -147,7 +147,7 @@ while (true) {
 ```
   </Tab>
   <Tab language="csharp" title="C#">
-```csharp maxLines=15
+```csharp highlight={37} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -233,7 +233,7 @@ using (var httpClient = new HttpClient())
 ```
   </Tab>
   <Tab language="ruby" title="Ruby">
-```ruby maxLines=15
+```ruby highlight={23-24} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -300,7 +300,7 @@ end
 ```
   </Tab>
   <Tab language="php" title="PHP">
-```php maxLines=15
+```php highlight={30-31} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-punctuation-and-casing.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-punctuation-and-casing.mdx
@@ -8,7 +8,7 @@ You can disable this behavior by setting `punctuate` and `format_text` to `False
 
 <Tabs>
   <Tab language="python-sdk" title="Python SDK" default>
-```python
+```python maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -27,7 +27,7 @@ print(transcript.text)
 ```
   </Tab>
   <Tab language="python" title="Python">
-```python
+```python maxLines=15
 import requests
 import time
 
@@ -72,7 +72,7 @@ while True:
 ```
   </Tab>
   <Tab language="typescript-sdk" title="TypeScript SDK" default>
-```ts
+```ts maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -99,7 +99,7 @@ run()
 ```
   </Tab>
   <Tab language="typescript" title="TypeScript">
-```ts
+```ts maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -147,7 +147,7 @@ while (true) {
 ```
   </Tab>
   <Tab language="csharp" title="C#">
-```csharp
+```csharp maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -233,7 +233,7 @@ using (var httpClient = new HttpClient())
 ```
   </Tab>
   <Tab language="ruby" title="Ruby">
-```ruby
+```ruby maxLines=15
 require 'net/http'
 require 'json'
 
@@ -300,7 +300,7 @@ end
 ```
   </Tab>
   <Tab language="php" title="PHP">
-```php
+```php maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/custom-spelling.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/custom-spelling.mdx
@@ -8,7 +8,7 @@ Custom Spelling lets you customize how words are spelled or formatted in the tra
   <Tab language="python-sdk" title="Python SDK" default>
 To use Custom Spelling, pass a dictionary to `set_custom_spelling()` on the transcription config. Each key-value pair specifies a mapping from a word or phrase to a new spelling or format. The key specifies the new spelling or format, and the corresponding value is the word or phrase you want to replace.
 
-```python maxLines=15
+```python highlight={9-14} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -36,7 +36,7 @@ print(transcript.text)
   <Tab language="python" title="Python">
 To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be a list of dictionaries, with each dictionary specifying a mapping from a word or phrase to a new spelling or format.
 
-```python maxLines=15
+```python highlight={19-28} maxLines=15
 import requests
 import time
 
@@ -91,7 +91,7 @@ while True:
   <Tab language="typescript-sdk" title="TypeScript SDK" default>
 To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of objects, with each object specifying a mapping from a word or phrase to a new spelling or format.
 
-```ts maxLines=15
+```ts highlight={13-22} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -128,7 +128,7 @@ run()
   </Tab>
   <Tab language="typescript" title="TypeScript">
   To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of objects, with each object specifying a mapping from a word or phrase to a new spelling or format.
-```ts maxLines=15
+```ts highlight={19-28} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -186,7 +186,7 @@ while (true) {
   </Tab>
   <Tab language="csharp" title="C#">
   To use Custom Spelling, include `custom_spelling` in your transcription request. The parameter should be an array of objects, with each object specifying a mapping from a word or phrase to a new spelling or format.
-```csharp maxLines=15
+```csharp highlight={37-46} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -282,7 +282,7 @@ using (var httpClient = new HttpClient())
   </Tab>
   <Tab language="ruby" title="Ruby">
   To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of hashes, with each hash specifying a mapping from a word or phrase to a new spelling or format.
-```ruby maxLines=15
+```ruby highlight={23-32} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -358,7 +358,7 @@ end
   </Tab>
   <Tab language="php" title="PHP">
   To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of arrays, with each inner array specifying a mapping from a word or phrase to a new spelling or format.
-```php maxLines=15
+```php highlight={30-39} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/custom-spelling.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/custom-spelling.mdx
@@ -8,7 +8,7 @@ Custom Spelling lets you customize how words are spelled or formatted in the tra
   <Tab language="python-sdk" title="Python SDK" default>
 To use Custom Spelling, pass a dictionary to `set_custom_spelling()` on the transcription config. Each key-value pair specifies a mapping from a word or phrase to a new spelling or format. The key specifies the new spelling or format, and the corresponding value is the word or phrase you want to replace.
 
-```python
+```python maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -36,7 +36,7 @@ print(transcript.text)
   <Tab language="python" title="Python">
 To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be a list of dictionaries, with each dictionary specifying a mapping from a word or phrase to a new spelling or format.
 
-```python
+```python maxLines=15
 import requests
 import time
 
@@ -91,7 +91,7 @@ while True:
   <Tab language="typescript-sdk" title="TypeScript SDK" default>
 To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of objects, with each object specifying a mapping from a word or phrase to a new spelling or format.
 
-```ts
+```ts maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -128,7 +128,7 @@ run()
   </Tab>
   <Tab language="typescript" title="TypeScript">
   To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of objects, with each object specifying a mapping from a word or phrase to a new spelling or format.
-```ts
+```ts maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -186,7 +186,7 @@ while (true) {
   </Tab>
   <Tab language="csharp" title="C#">
   To use Custom Spelling, include `custom_spelling` in your transcription request. The parameter should be an array of objects, with each object specifying a mapping from a word or phrase to a new spelling or format.
-```csharp
+```csharp maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -282,7 +282,7 @@ using (var httpClient = new HttpClient())
   </Tab>
   <Tab language="ruby" title="Ruby">
   To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of hashes, with each hash specifying a mapping from a word or phrase to a new spelling or format.
-```ruby
+```ruby maxLines=15
 require 'net/http'
 require 'json'
 
@@ -358,7 +358,7 @@ end
   </Tab>
   <Tab language="php" title="PHP">
   To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of arrays, with each inner array specifying a mapping from a word or phrase to a new spelling or format.
-```php
+```php maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/custom-vocabulary.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/custom-vocabulary.mdx
@@ -152,7 +152,7 @@ while (true) {
 
 ```
 
-```csharp title="C#" highlight={39} maxLines=15
+```csharp title="C#" highlight={37} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/custom-vocabulary.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/custom-vocabulary.mdx
@@ -14,7 +14,7 @@ You can also control how much weight to apply to each keyword or phrase. Include
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={9-10} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -35,7 +35,7 @@ if transcript.status == "error":
 print(transcript.text)
 ```
 
-```python title="Python"
+```python title="Python" highlight={19,20} maxLines=15
 import requests
 import time
 
@@ -79,7 +79,7 @@ while True:
 
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={13-14} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -105,7 +105,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={19-20} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -152,7 +152,7 @@ while (true) {
 
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={39} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -236,7 +236,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={23-24} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -302,7 +302,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={30-31} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/delete-transcripts.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/delete-transcripts.mdx
@@ -6,7 +6,7 @@ You can remove the data from the transcript and mark it as deleted.
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={17} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -29,7 +29,7 @@ transcript = aai.Transcript.get_by_id(transcript.id)
 print(transcript.text)
 ```
 
-```python title="Python"
+```python title="Python" highlight={40} maxLines=15
 import requests
 import time
 
@@ -74,7 +74,7 @@ response = requests.delete(polling_endpoint, headers=headers)
 print(response.json()['text'])
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={20} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -102,7 +102,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={43-45} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -152,7 +152,7 @@ const res = await axios.delete(pollingEndpoint, {
 console.log(res.data.text)
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={70-76} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -247,7 +247,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={63} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -317,7 +317,7 @@ delete_response_body = JSON.parse(delete_response.body)
 puts "Transcript deleted: #{delete_response_body['text']}"
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={75} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/export-paragraphs-and-sentences.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/export-paragraphs-and-sentences.mdx
@@ -8,7 +8,7 @@ You can retrieve transcripts that are automatically segmented into paragraphs. T
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={15-18} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -29,7 +29,7 @@ for paragraph in paragraphs:
   print()
 ```
 
-```python title="Python"
+```python title="Python" highlight={40} maxLines=15
 import requests
 import time
 
@@ -75,7 +75,7 @@ for paragraph in paragraphs:
   print()
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={17} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -101,7 +101,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={45} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -155,7 +155,7 @@ for (const paragraph of paragraphs) {
 }
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={84-91} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -267,7 +267,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={65} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -343,7 +343,7 @@ paragraphs.each do |paragraph|
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={75} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -433,7 +433,7 @@ foreach ($paragraphs as $paragraph) {
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={15-18} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -454,7 +454,7 @@ for sentence in sentences:
   print()
 ```
 
-```python title="Python"
+```python title="Python" highlight={40} maxLines=15
 import requests
 import time
 
@@ -500,7 +500,7 @@ for sentence in sentences:
   print()
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={17} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -526,7 +526,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={45} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -580,7 +580,7 @@ for (const sentence of sentences) {
 }
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={84-91} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -692,7 +692,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={65} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -768,7 +768,7 @@ sentences.each do |sentence|
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={75} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/export-srt-or-vtt-caption-files.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/export-srt-or-vtt-caption-files.mdx
@@ -8,7 +8,7 @@ You can also customize the maximum number of characters per caption by specifyin
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={15-18} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -38,7 +38,7 @@ with open(f"transcript_{transcript.id}.srt", "w") as srt_file:
 
 ```
 
-```python title="Python"
+```python title="Python" highlight={41} maxLines=15
 import requests
 import time
 
@@ -90,7 +90,7 @@ with open(f"transcript_{transcript_id}.srt", "w") as srt_file:
 #   vtt_file.write(vtt_response.text)
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={19} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 import fs from 'fs'
 
@@ -119,7 +119,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={44} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -175,7 +175,7 @@ fs.writeFileSync(`transcript_${transcriptId}.srt`, srt)
 // fs.writeFileSync(`transcript_${transcriptId}.vtt`, vtt)
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={70-76} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -279,7 +279,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={66} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -361,7 +361,7 @@ File.write("transcript_#{transcript_id}.srt", srt)
 # File.write("transcript_#{transcript_id}.vtt", vtt)
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={75} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/filler-words.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/filler-words.mdx
@@ -19,7 +19,7 @@ If you want to keep filler words in the transcript, you can set the `disfluencie
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={8} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -37,7 +37,7 @@ if transcript.status == "error":
 print(transcript.text)
 ```
 
-```python title="Python"
+```python title="Python" highlight={19} maxLines=15
 import requests
 import time
 
@@ -80,7 +80,7 @@ while True:
 
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={13} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -105,7 +105,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={19} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -151,7 +151,7 @@ while (true) {
 
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={37} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -235,7 +235,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={23} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -300,7 +300,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={30} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/index.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/index.mdx
@@ -15,7 +15,7 @@ Choose between [_Best_ and _Nano_](/docs/speech-to-text/pre-recorded-audio/selec
 The following example transcribes an audio file from a local file.
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -33,7 +33,7 @@ if transcript.status == "error":
 print(transcript.text)
 ```
 
-```python title="Python"
+```python title="Python" maxLines=15
 import requests
 import time
 
@@ -75,7 +75,7 @@ while True:
 
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -99,7 +99,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -144,7 +144,7 @@ while (true) {
 
 ```
 
-```csharp title="C#"
+```csharp title="C#" maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -228,7 +228,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" maxLines=15
 require 'net/http'
 require 'json'
 
@@ -292,7 +292,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -365,7 +365,7 @@ while (true) {
 </CodeBlocks>
 # Example output
 
-```plain
+```plain maxLines=15
 Smoke from hundreds of wildfires in Canada is triggering air quality alerts
 throughout the US. Skylines from Maine to Maryland to Minnesota are gray and
 smoggy. And...

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/multichannel-transcription.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/multichannel-transcription.mdx
@@ -312,7 +312,7 @@ while true
 end
 ```
 
-```php title="PHP" highlight={75} maxLines=15
+```php title="PHP" highlight={30} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/multichannel-transcription.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/multichannel-transcription.mdx
@@ -13,7 +13,7 @@ Additionally, each word in the `words` array contains the channel identifier.
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={8, 15-16} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -32,7 +32,7 @@ for utterance in transcript.utterances:
   print(f"Channel {utterance.speaker}: {utterance.text}")
 ```
 
-```python title="Python"
+```python title="Python" highlight={19} maxLines=15
 import requests
 import time
 
@@ -77,7 +77,7 @@ for utterance in transcription_result['utterances']:
   print(f"Channel {utterance['speaker']}: {utterance['text']}")
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={13} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -104,7 +104,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={19} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -152,7 +152,7 @@ while (true) {
 
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={43} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -245,7 +245,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={23} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -312,7 +312,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={75} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -341,7 +341,8 @@ $upload_url = $response_data["upload_url"];
 curl_close($ch);
 
 $data = array(
-    "audio_url" => $upload_url // You can also use a URL to an audio or video file on the web
+    "audio_url" => $upload_url, // You can also use a URL to an audio or video file on the web
+    "multichannel" => true
 );
 
 $url = $base_url . "/v2/transcript";

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/profanity-filtering.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/profanity-filtering.mdx
@@ -8,7 +8,7 @@ Any profanity in the returned `text` will be replaced with asterisks.
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={8} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -26,7 +26,7 @@ if transcript.status == "error":
 print(transcript.text)
 ```
 
-```python title="Python"
+```python title="Python" highlight={19} maxLines=15
 import requests
 import time
 
@@ -69,7 +69,7 @@ while True:
 
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={13} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -94,7 +94,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={19} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -140,7 +140,7 @@ while (true) {
 
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={37} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -224,7 +224,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={23} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -289,7 +289,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={30} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/select-the-region.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/select-the-region.mdx
@@ -19,7 +19,7 @@ To use the EU endpoint, set the base URL for your requests as `api.eu.assemblyai
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={4} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -38,7 +38,7 @@ if transcript.status == "error":
 print(transcript.text)
 ```
 
-```python title="Python"
+```python title="Python" highlight={4} maxLines=15
 import requests
 import time
 
@@ -80,7 +80,7 @@ while True:
 
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={5} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -105,7 +105,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={4} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -150,7 +150,7 @@ while (true) {
 
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={40} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -234,7 +234,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={4} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -298,7 +298,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={5} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano.mdx
@@ -31,7 +31,7 @@ You can visit our <a href="https://www.assemblyai.com/pricing" target="_blank">p
   <Tab language="python-sdk" title="Python SDK" default>
 You can change the model by setting the `speech_model` in the transcription config:
 
-```python maxLines=15
+```python highlight={9} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano.mdx
@@ -99,7 +99,7 @@ while True:
   <Tab language="typescript-sdk" title="TypeScript SDK" default>
   You can change the model by setting the `speech_model` in the transcript parameters:
 
-```ts maxLines=15
+```ts highlight={13} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -127,7 +127,7 @@ run()
   <Tab language="typescript" title="TypeScript">
   You can change the model by setting the `speech_model` in the POST request body:
 
-```ts maxLines=15
+```ts highlight={19} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -145,7 +145,8 @@ const uploadResponse = await axios.post(`${baseUrl}/v2/upload`, audioData, {
 const uploadUrl = uploadResponse.data.upload_url
 
 const data = {
-  audio_url: uploadUrl // You can also use a URL to an audio or video file on the web
+  audio_url: uploadUrl, // You can also use a URL to an audio or video file on the web
+  speech_model: 'nano'
 }
 
 const url = `${baseUrl}/v2/transcript`
@@ -174,7 +175,7 @@ while (true) {
   </Tab>
   <Tab language="csharp" title="C#">
   You can change the model by setting the `speech_model` in the POST request body:
-```csharp maxLines=15
+```csharp highlight={37} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -259,7 +260,7 @@ using (var httpClient = new HttpClient())
 ```
   </Tab>
   <Tab language="ruby" title="Ruby">
-```ruby maxLines=15
+```ruby highlight={23} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -325,7 +326,7 @@ end
 ```
   </Tab>
   <Tab language="php" title="PHP">
-```php maxLines=15
+```php highlight={30} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano.mdx
@@ -31,7 +31,7 @@ You can visit our <a href="https://www.assemblyai.com/pricing" target="_blank">p
   <Tab language="python-sdk" title="Python SDK" default>
 You can change the model by setting the `speech_model` in the transcription config:
 
-```python
+```python maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -53,7 +53,7 @@ print(transcript.text)
   <Tab language="python" title="Python">
   You can change the model by setting the `speech_model` in the POST request body:
 
-```python
+```python highlight={19} maxLines=15
 import requests
 import time
 
@@ -99,7 +99,7 @@ while True:
   <Tab language="typescript-sdk" title="TypeScript SDK" default>
   You can change the model by setting the `speech_model` in the transcript parameters:
 
-```ts
+```ts maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -127,7 +127,7 @@ run()
   <Tab language="typescript" title="TypeScript">
   You can change the model by setting the `speech_model` in the POST request body:
 
-```ts
+```ts maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -174,7 +174,7 @@ while (true) {
   </Tab>
   <Tab language="csharp" title="C#">
   You can change the model by setting the `speech_model` in the POST request body:
-```csharp
+```csharp maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -259,7 +259,7 @@ using (var httpClient = new HttpClient())
 ```
   </Tab>
   <Tab language="ruby" title="Ruby">
-```ruby
+```ruby maxLines=15
 require 'net/http'
 require 'json'
 
@@ -325,7 +325,7 @@ end
 ```
   </Tab>
   <Tab language="php" title="PHP">
-```php
+```php maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/set-language-manually.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/set-language-manually.mdx
@@ -138,7 +138,7 @@ while (true) {
 
 ```
 
-```csharp title="C#" highlight={39} maxLines=15
+```csharp title="C#" highlight={37} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/set-language-manually.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/set-language-manually.mdx
@@ -6,7 +6,7 @@ If you already know the dominant language, you can use the `language_code` key t
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={8} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -24,7 +24,7 @@ if transcript.status == "error":
 print(transcript.text)
 ```
 
-```python title="Python"
+```python title="Python" highlight={19} maxLines=15
 import requests
 import time
 
@@ -67,7 +67,7 @@ while True:
 
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={13} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -92,7 +92,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={19} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -138,7 +138,7 @@ while (true) {
 
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={39} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -222,7 +222,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={23} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -287,7 +287,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={30} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/set-the-start-and-end-of-the-transcript.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/set-the-start-and-end-of-the-transcript.mdx
@@ -6,7 +6,7 @@ If you only want to transcribe a portion of your file, you can set the `audio_st
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={8-11} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -27,7 +27,7 @@ if transcript.status == "error":
 print(transcript.text)
 ```
 
-```python title="Python"
+```python title="Python" highlight={19,20} maxLines=15
 import requests
 import time
 
@@ -71,7 +71,7 @@ while True:
 
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={13-14} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -97,7 +97,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={19-20} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -144,7 +144,7 @@ while (true) {
 
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={37} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -228,7 +228,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={23-24} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -294,7 +294,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={30-31} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/speaker-diarization.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/speaker-diarization.mdx
@@ -125,7 +125,7 @@ run()
 
   </Tab>
   <Tab language="typescript" title="TypeScript">
-```ts maxLines=15
+```ts highlight={19, 35-37} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -174,7 +174,7 @@ while (true) {
 ```
   </Tab>
   <Tab language="csharp" title="C#">
-```csharp maxLines=15
+```csharp highlight={44, 87-90} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -269,7 +269,7 @@ using (var httpClient = new HttpClient())
 ```
   </Tab>
   <Tab language="ruby" title="Ruby">
-```ruby maxLines=15
+```ruby highlight={23, 54-55} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -337,7 +337,7 @@ end
 ```
   </Tab>
   <Tab language="php" title="PHP">
-```php maxLines=15
+```php highlight={30, 61-63} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/speaker-diarization.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/speaker-diarization.mdx
@@ -19,7 +19,7 @@ Speaker Diarization doesn't support multichannel transcription. Enabling both Sp
   <Tab language="python-sdk" title="Python SDK" default>
 To enable Speaker Diarization, set `speaker_labels` to `True` in the transcription config.
 
-```python {14,19-20}
+```python {14,19-20} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -46,7 +46,7 @@ for utterance in transcript.utterances:
   <Tab language="python" title="Python">
 To enable Speaker Diarization, set `speaker_labels` to `True` in the POST request body:
 
-```python
+```python {19,41,42} maxLines=15
 import requests
 import time
 
@@ -94,7 +94,7 @@ for utterance in transcription_result['utterances']:
   <Tab language="typescript-sdk" title="TypeScript SDK">
 To enable Speaker Diarization, set `speaker_labels` to `true` in the transcription config.
 
-```ts {15,21-23}
+```ts {15,21-23} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -125,7 +125,7 @@ run()
 
   </Tab>
   <Tab language="typescript" title="TypeScript">
-```ts
+```ts maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -174,7 +174,7 @@ while (true) {
 ```
   </Tab>
   <Tab language="csharp" title="C#">
-```csharp
+```csharp maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -269,7 +269,7 @@ using (var httpClient = new HttpClient())
 ```
   </Tab>
   <Tab language="ruby" title="Ruby">
-```ruby
+```ruby maxLines=15
 require 'net/http'
 require 'json'
 
@@ -337,7 +337,7 @@ end
 ```
   </Tab>
   <Tab language="php" title="PHP">
-```php
+```php maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -417,7 +417,7 @@ while (true) {
 
 ### Request
 
-```bash {6}
+```bash {6} maxLines=15
 curl https://api.assemblyai.com/v2/transcript \
 --header "Authorization: <YOUR_API_KEY>" \
 --header "Content-Type: application/json" \

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/speech-threshold.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/speech-threshold.mdx
@@ -6,13 +6,13 @@ To only transcribe files that contain at least a specified percentage of spoken 
 
 If the percentage of speech in the audio file is below the provided threshold, the value of `text` is `None` and the response contains an `error` message:
 
-```plain
+```plain maxLines=15
 Audio speech threshold 0.9461 is below the requested speech threshold value 1.0
 ```
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={8} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -30,7 +30,7 @@ if transcript.status == "error":
 print(transcript.text)
 ```
 
-```python title="Python"
+```python title="Python" highlight={19} maxLines=15
 import requests
 import time
 
@@ -73,7 +73,7 @@ while True:
 
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={13} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -102,7 +102,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={19} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -148,7 +148,7 @@ while (true) {
 
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={37} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -232,7 +232,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={23} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -297,7 +297,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={30} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/template_codesnippet.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/template_codesnippet.mdx
@@ -1,6 +1,6 @@
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -18,7 +18,7 @@ if transcript.status == "error":
 print(transcript.text)
 ```
 
-```python title="Python"
+```python title="Python" maxLines=15
 import requests
 import time
 
@@ -60,7 +60,7 @@ while True:
 
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -84,7 +84,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -129,7 +129,7 @@ while (true) {
 
 ```
 
-```csharp title="C#"
+```csharp title="C#" maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -213,7 +213,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" maxLines=15
 require 'net/http'
 require 'json'
 
@@ -277,7 +277,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -352,7 +352,7 @@ while (true) {
 
 <Tabs>
   <Tab language="python-sdk" title="Python SDK" default>
-```python
+```python maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -371,7 +371,7 @@ print(transcript.text)
 ```
   </Tab>
   <Tab language="python" title="Python">
-```python
+```python maxLines=15
 import requests
 import time
 
@@ -414,7 +414,7 @@ while True:
 ```
   </Tab>
   <Tab language="typescript-sdk" title="TypeScript SDK" default>
-```ts
+```ts maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -439,7 +439,7 @@ run()
 ```
   </Tab>
   <Tab language="typescript" title="TypeScript">
-```ts
+```ts maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -485,7 +485,7 @@ while (true) {
 ```
   </Tab>
   <Tab language="csharp" title="C#">
-```csharp
+```csharp maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -570,7 +570,7 @@ using (var httpClient = new HttpClient())
 ```
   </Tab>
   <Tab language="ruby" title="Ruby">
-```ruby
+```ruby maxLines=15
 require 'net/http'
 require 'json'
 
@@ -635,7 +635,7 @@ end
 ```
   </Tab>
   <Tab language="php" title="PHP">
-```php
+```php maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/transcript-status.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/transcript-status.mdx
@@ -302,7 +302,7 @@ while true
 end
 ```
 
-```php title="PHP" maxLines=15
+```php title="PHP" highlight={62-63} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/transcript-status.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/transcript-status.mdx
@@ -17,7 +17,7 @@ If the transcription fails, the status of the transcript is `error`, and the tra
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={12} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -36,7 +36,7 @@ if transcript.status == aai.TranscriptStatus.error:
 print(transcript.text)
 ```
 
-```python title="Python"
+```python title="Python" highlight={36} maxLines=15
 import requests
 import json
 import time
@@ -78,7 +78,7 @@ while True:
     time.sleep(3)
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={18}maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -107,7 +107,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={36} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -151,7 +151,7 @@ while (true) {
 }
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={66-67} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -238,7 +238,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={55-56} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -302,7 +302,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/word-level-timestamps.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/word-level-timestamps.mdx
@@ -6,7 +6,7 @@ The response also includes an array with information about each word:
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={13} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -22,7 +22,7 @@ for word in transcript.words:
   print(f"Word: {word.text}, Start: {word.start}, End: {word.end}, Confidence: {word.confidence}")
 ```
 
-```python title="Python"
+```python title="Python" highlight={33} maxLines=15
 import requests
 import json
 import time
@@ -66,7 +66,7 @@ while True:
 
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={22} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -95,7 +95,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={37} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -143,7 +143,7 @@ while (true) {
 }
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={103} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -251,7 +251,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={55-56} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -319,7 +319,7 @@ while true
 end
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={62-65} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/word-search.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/word-search.mdx
@@ -8,7 +8,7 @@ The parameter can be a list of words, numbers, or phrases up to five words.
 
 <CodeBlocks>
 
-```python title="Python SDK"
+```python title="Python SDK" highlight={18} maxLines=15
 import assemblyai as aai
 
 aai.settings.api_key = "<YOUR_API_KEY>"
@@ -32,7 +32,7 @@ for match in matches:
   print(f"Found '{match.text}' {match.count} times in the transcript")
 ```
 
-```python title="Python"
+```python title="Python" highlight={42,44} maxLines=15
 import requests
 import time
 
@@ -82,7 +82,7 @@ for match in response_json['matches']:
   print(f"Found '{match['text']}' {match['count']} times in the transcript")
 ```
 
-```ts title="TypeScript SDK"
+```ts title="TypeScript SDK" highlight={21} maxLines=15
 import { AssemblyAI } from 'assemblyai'
 
 const client = new AssemblyAI({
@@ -113,7 +113,7 @@ const run = async () => {
 run()
 ```
 
-```ts title="TypeScript"
+```ts title="TypeScript" highlight={45-48} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
 
@@ -168,7 +168,7 @@ for (const match of response.data.matches) {
 }
 ```
 
-```csharp title="C#"
+```csharp title="C#" highlight={85-90} maxLines=15
 using System;
 using System.IO;
 using System.Net.Http;
@@ -279,7 +279,7 @@ using (var httpClient = new HttpClient())
 }
 ```
 
-```ruby title="Ruby"
+```ruby title="Ruby" highlight={69} maxLines=15
 require 'net/http'
 require 'json'
 
@@ -358,7 +358,7 @@ end
 
 ```
 
-```php title="PHP"
+```php title="PHP" highlight={76} maxLines=15
 <?php
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/fern/pages/03-audio-intelligence/key-phrases.mdx
+++ b/fern/pages/03-audio-intelligence/key-phrases.mdx
@@ -354,7 +354,7 @@ class Program
   
   Enable Key Phrases by setting `auto_highlights` to `true` in the JSON payload.
 
-```ruby {23}
+```ruby {22}
 require 'net/http'
 require 'json'
 

--- a/fern/pages/04-lemur/ask-questions.mdx
+++ b/fern/pages/04-lemur/ask-questions.mdx
@@ -928,7 +928,7 @@ end
 
   <Tab language="php" title="PHP">
 
-```php
+```php {42-64}
 <?php
 $base_url = "https://api.assemblyai.com";
 $headers = array(

--- a/fern/pages/04-lemur/summarize-audio.mdx
+++ b/fern/pages/04-lemur/summarize-audio.mdx
@@ -823,7 +823,7 @@ puts lemur_result["response"]
 
   <Tab language="php" title="PHP">
 
-```php
+```php {42-53}
 <?php
 $base_url = "https://api.assemblyai.com";
 $headers = array(

--- a/fern/scroll-highlighted-lines.js
+++ b/fern/scroll-highlighted-lines.js
@@ -1,34 +1,33 @@
 // Function to scroll highlighted lines into view
 function scrollHighlightedLines() {
-  // Find all code blocks
-  const codeBlocks = document.querySelectorAll('.code-block-root');
-  
-  codeBlocks.forEach(block => {
-    // Find the scrollable viewport within this code block
+  document.querySelectorAll('.code-block-root').forEach(block => {
     const viewport = block.querySelector('[data-radix-scroll-area-viewport]');
-    
     if (viewport) {
-      // Find all highlighted lines within this code block
       const highlightedLines = block.querySelectorAll('.code-block-line.highlight');
-      
       if (highlightedLines.length > 0) {
-        // If there are multiple highlighted lines, scroll to the first one
         const firstHighlightedLine = highlightedLines[0];
+        const allLines = block.querySelectorAll('.code-block-line');
+        const lineHeight = firstHighlightedLine.clientHeight;
+        const viewportHeight = viewport.clientHeight;
+        const visibleLines = Math.floor(viewportHeight / lineHeight);
+        // -1 because it looks better in my opinion
+        const linesAbove = Math.floor(visibleLines / 2) - 1;
         
-        // Scroll the line into view
-        firstHighlightedLine.scrollIntoView({
-          behavior: 'auto',
-          block: 'center' // Centers the line in the visible area
-        });
+        viewport.scrollTop = firstHighlightedLine.offsetTop - (linesAbove * lineHeight);
       }
     }
   });
 }
 
-// Run when the page loads
+// Run on initial load and navigation
+scrollHighlightedLines();
 document.addEventListener('DOMContentLoaded', scrollHighlightedLines);
 
-// Also run when the page is fully loaded (in case DOMContentLoaded fired too early)
-if (document.readyState === 'complete') {
-  scrollHighlightedLines();
+if (typeof window !== 'undefined') {
+  window.addEventListener('popstate', scrollHighlightedLines);
+  document.addEventListener('next-navigation', scrollHighlightedLines);
+  document.addEventListener('routeChangeComplete', scrollHighlightedLines);
+  
+  const observer = new MutationObserver(scrollHighlightedLines);
+  observer.observe(document.body, { childList: true, subtree: true });
 } 

--- a/fern/scroll-highlighted-lines.js
+++ b/fern/scroll-highlighted-lines.js
@@ -1,0 +1,34 @@
+// Function to scroll highlighted lines into view
+function scrollHighlightedLines() {
+  // Find all code blocks
+  const codeBlocks = document.querySelectorAll('.code-block-root');
+  
+  codeBlocks.forEach(block => {
+    // Find the scrollable viewport within this code block
+    const viewport = block.querySelector('[data-radix-scroll-area-viewport]');
+    
+    if (viewport) {
+      // Find all highlighted lines within this code block
+      const highlightedLines = block.querySelectorAll('.code-block-line.highlight');
+      
+      if (highlightedLines.length > 0) {
+        // If there are multiple highlighted lines, scroll to the first one
+        const firstHighlightedLine = highlightedLines[0];
+        
+        // Scroll the line into view
+        firstHighlightedLine.scrollIntoView({
+          behavior: 'auto',
+          block: 'center' // Centers the line in the visible area
+        });
+      }
+    }
+  });
+}
+
+// Run when the page loads
+document.addEventListener('DOMContentLoaded', scrollHighlightedLines);
+
+// Also run when the page is fully loaded (in case DOMContentLoaded fired too early)
+if (document.readyState === 'complete') {
+  scrollHighlightedLines();
+} 


### PR DESCRIPTION
This PR adds functionality to automatically scroll highlighted lines into view within code blocks. When a code block contains highlighted lines (e.g., `highlight={19}`), the script will:

- Detect code blocks with highlighted lines
- Calculate the optimal scroll position to center the highlighted line
- Automatically scroll the code block's viewport to show the highlighted line
- Maintain this behavior during page loads and client-side navigation

This improves the user experience by ensuring highlighted lines are immediately visible without requiring manual scrolling, particularly useful in documentation where specific lines are referenced.

**Before:**
<img width="750" alt="image" src="https://github.com/user-attachments/assets/3e92798c-344c-4955-9380-6f9caabefa63" />

**After:**
<img width="738" alt="image" src="https://github.com/user-attachments/assets/73811445-efb7-460e-9897-3e49a423ffec" />
