### PR TITLE
Michelle/supported languages

### DIFF
--- a/cookbook-master/core-transcription/automatic-language-detection-route-default-language-js.md
+++ b/cookbook-master/core-transcription/automatic-language-detection-route-default-language-js.md
@@ -30,7 +30,7 @@ const client = new AssemblyAI({
 });
 ```
 
-Define a `default_language`, which should be set to the [language code](https://www.assemblyai.com/docs/speech-to-text/pre-recorded-audio/supported-languages) that will be used to rerun the transcript if language detection runs with low `language_confidence`.
+Define a `default_language`, which should be set to the [language code](https://www.assemblyai.com/docs/getting-started/supported-languages) that will be used to rerun the transcript if language detection runs with low `language_confidence`.
 
 ```js
 const default_language = 'LANGUAGE_CODE';

--- a/fern/cookbooks/core-transcription/automatic-language-detection-route-default-language-python.mdx
+++ b/fern/cookbooks/core-transcription/automatic-language-detection-route-default-language-python.mdx
@@ -33,7 +33,7 @@ import assemblyai as aai
 aai.settings.api_key = "YOUR_API_KEY"
 ```
 
-Define a `default_language`, which will be set to the [language code](https://www.assemblyai.com/docs/speech-to-text/pre-recorded-audio/supported-languages) that will be used in case the detected language has a low `language_confidence`. 
+Define a `default_language`, which will be set to the [language code](https://www.assemblyai.com/docs/getting-started/supported-languages) that will be used in case the detected language has a low `language_confidence`. 
 
 
 ```python

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -79,6 +79,10 @@ navigation:
               - page: Ruby
                 path: pages/01-getting-started/transcribe-streaming-audio-from-a-microphone/ruby.mdx
                 slug: /ruby
+          - page: Supported languages
+            path: pages/01-getting-started/supported-languages.mdx
+            slug: /getting-started/supported-languages
+          
       - section: Build with AssemblyAI
         skip-slug: true
         contents:
@@ -536,8 +540,6 @@ navigation:
               - section: Language settings
                 skip-slug: true
                 contents:
-                - page: Supported languages
-                  path: pages/01-getting-started/supported-languages.mdx
                 - page: Automatic language detection
                   path: pages/02-speech-to-text/pre-recorded-audio/automatic-language-detection.mdx
                 - page: Set language manually

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -108,7 +108,7 @@ navigation:
               - page: Identifying Hate Speech in Audio or Video Files
                 path: pages/05-guides/identifying-hate-speech-in-audio-or-video-files.mdx
                 hidden: true
-              - page: How to Identify Highlights in Audio or Video Files
+              - page: Identifying Highlights in Audio or Video Files
                 path: pages/05-guides/identifying-highlights-in-audio-or-video-files.mdx
                 hidden: true
               - page: Identifying Speakers in Audio Recordings

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -740,7 +740,7 @@ analytics:
 redirects:
   # pages that have moved
   - source: /docs/speech-to-text/supported-languages
-    destination: /docs/speech-to-text/pre-recorded-audio/supported-languages
+    destination: /docs/getting-started/supported-languages
   - source: /docs/speech-to-text/speaker-diarization
     destination: /docs/speech-to-text/pre-recorded-audio/speaker-diarization
   - source: /docs/getting-started/apply-llms-to-audio-files

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-language-detection.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-language-detection.mdx
@@ -2,7 +2,7 @@
 title: 'Automatic language detection'
 ---
 
-Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/getting-started/supported-languages).
 
 To reliably identify the dominant language, the file must contain **at least 50 seconds** of spoken audio.
 

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano.mdx
@@ -398,4 +398,4 @@ while (true) {
   </Tab>
 </Tabs>
 
-For a list of the supported languages for each model, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+For a list of the supported languages for each model, see [Supported languages](/docs/getting-started/supported-languages).

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/set-language-manually.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/set-language-manually.mdx
@@ -361,4 +361,4 @@ while (true) {
 </CodeBlocks>
 
 
-To see all supported languages and their codes, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+To see all supported languages and their codes, see [Supported languages](/docs/getting-started/supported-languages).

--- a/fern/pages/02-speech-to-text/speech-recognition.mdx
+++ b/fern/pages/02-speech-to-text/speech-recognition.mdx
@@ -533,7 +533,7 @@ transcript = client.transcripts.transcribe(
   </Tab>
 </Tabs>
 
-For a list of the supported languages for each model, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+For a list of the supported languages for each model, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 ## Select the region
@@ -706,7 +706,7 @@ transcript = client.transcripts.transcribe(
 
 ## Automatic language detection
 
-Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/getting-started/supported-languages).
 
 To reliably identify the dominant language, the file must contain **at least 50 seconds** of spoken audio.
 
@@ -962,7 +962,7 @@ transcript = client.transcripts.transcribe(
   </Tab>
 </Tabs>
 
-To see all supported languages and their codes, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+To see all supported languages and their codes, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 

--- a/fern/pages/02-speech-to-text/streaming.mdx
+++ b/fern/pages/02-speech-to-text/streaming.mdx
@@ -370,7 +370,7 @@ The expiration time must be a value between 60 and 360000 seconds.
 The client should retrieve the token from the server and use the token to authenticate the transcriber.
 
 <Note>
-Each token has a one-time use restriction and can only be used for a single session.
+Each token has a one-time use restriction and can only be used for a single session. Any usage associated with a temporary token will be attributed to the API key that generated it.
 </Note>
 
 <Tabs groupId="language">

--- a/fern/pages/03-audio-intelligence/entity-detection.mdx
+++ b/fern/pages/03-audio-intelligence/entity-detection.mdx
@@ -22,7 +22,7 @@ Here are a few examples of what you can detect:
 For the full list of entities that you can detect, see [Supported entities](#supported-entities).
 
 <Tip title="Supported languages">
-Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Entity Detection is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 

--- a/fern/pages/03-audio-intelligence/pii-redaction.mdx
+++ b/fern/pages/03-audio-intelligence/pii-redaction.mdx
@@ -19,7 +19,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
-PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+PII Redaction is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 <Warning title="Redacted properties">

--- a/fern/pages/05-guides/automatic-language-detection-workflow.mdx
+++ b/fern/pages/05-guides/automatic-language-detection-workflow.mdx
@@ -16,7 +16,7 @@ Performing ALD with this workflow has a few benefits:
 - Cost-effective language detection
 - Ability to detect 99 languages
 - Ability to use Nano as fallback if the language is not supported in Best
-- Ability to enable [Audio Intelligence models](/audio-intelligence) if the [language is supported](/docs/speech-to-text/pre-recorded-audio/supported-languages)
+- Ability to enable [Audio Intelligence models](/audio-intelligence) if the [language is supported](/docs/getting-started/supported-languages)
 - Ability to use [LeMUR](/lemur) with LLM prompts in Spanish for Spanish audio
 
 
@@ -52,7 +52,7 @@ import assemblyai as aai
 aai.settings.api_key = "<YOUR_API_KEY>"
 ```
 
-Create a set with all supported languages for Best. You can find them in our [documentation here](/docs/speech-to-text/pre-recorded-audio/supported-languages#supported-languages-for-best).
+Create a set with all supported languages for Best. You can find them in our [documentation here](/docs/getting-started/supported-languages#supported-languages-for-best).
 
 ```python
 supported_languages_for_best = {

--- a/fern/pages/05-guides/cookbooks/core-transcription/automatic-language-detection-route-default-language.mdx
+++ b/fern/pages/05-guides/cookbooks/core-transcription/automatic-language-detection-route-default-language.mdx
@@ -41,7 +41,7 @@ aai.settings.api_key = "YOUR_API_KEY"
 
 
 
-Define a `default_language`, which should be set to the [language code](https://www.assemblyai.com/docs/speech-to-text/pre-recorded-audio/supported-languages) that will be used to rerun the transcript if language detection runs with low `language_confidence`.
+Define a `default_language`, which should be set to the [language code](https://www.assemblyai.com/docs/getting-started/supported-languages) that will be used to rerun the transcript if language detection runs with low `language_confidence`.
 <CodeBlocks>
 ```js
 const default_language = 'LANGUAGE_CODE';

--- a/fern/pages/05-guides/sdks/csharp/csharp-async.mdx
+++ b/fern/pages/05-guides/sdks/csharp/csharp-async.mdx
@@ -157,7 +157,7 @@ var transcript = await client.Transcripts.TranscribeAsync(new TranscriptParams
 
   
 
-For a list of the supported languages for each model, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+For a list of the supported languages for each model, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 ## Select the region
@@ -218,7 +218,7 @@ var transcript = await client.Transcripts.TranscribeAsync(new TranscriptParams
 
 ## Automatic language detection
 
-Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/getting-started/supported-languages).
 
 To reliably identify the dominant language, the file must contain **at least 50 seconds** of spoken audio.
 
@@ -266,7 +266,7 @@ var transcript = await client.Transcripts.TranscribeAsync(new TranscriptParams
 
   
 
-To see all supported languages and their codes, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+To see all supported languages and their codes, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 

--- a/fern/pages/05-guides/sdks/csharp/csharp-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/csharp/csharp-audio-intelligence.mdx
@@ -195,7 +195,7 @@ Here are a few examples of what you can detect:
 For the full list of entities that you can detect, see [Supported entities](#supported-entities).
 
 <Tip title="Supported languages">
-Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Entity Detection is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 **Quickstart**
@@ -309,7 +309,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
-PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+PII Redaction is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 <Warning title="Redacted properties">

--- a/fern/pages/05-guides/sdks/go/go-async.mdx
+++ b/fern/pages/05-guides/sdks/go/go-async.mdx
@@ -154,7 +154,7 @@ transcript, _ := client.Transcripts.TranscribeFromURL(ctx, audioURL, &aai.Transc
 
   
 
-For a list of the supported languages for each model, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+For a list of the supported languages for each model, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 ## Select the region
@@ -208,7 +208,7 @@ transcript, _ := client.Transcripts.TranscribeFromURL(ctx, audioURL, &aai.Transc
 
 ## Automatic language detection
 
-Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/getting-started/supported-languages).
 
 To reliably identify the dominant language, the file must contain **at least 50 seconds** of spoken audio.
 
@@ -275,7 +275,7 @@ transcript, _ := client.Transcripts.TranscribeFromURL(ctx, audioURL, &aai.Transc
 
   
 
-To see all supported languages and their codes, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+To see all supported languages and their codes, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 

--- a/fern/pages/05-guides/sdks/go/go-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/go/go-audio-intelligence.mdx
@@ -218,7 +218,7 @@ Here are a few examples of what you can detect:
 For the full list of entities that you can detect, see [Supported entities](#supported-entities).
 
 <Tip title="Supported languages">
-Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Entity Detection is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 **Quickstart**
@@ -356,7 +356,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
-PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+PII Redaction is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 <Warning title="Redacted properties">

--- a/fern/pages/05-guides/sdks/java/java-async.mdx
+++ b/fern/pages/05-guides/sdks/java/java-async.mdx
@@ -144,7 +144,7 @@ var params = TranscriptOptionalParams.builder()
 
   
 
-For a list of the supported languages for each model, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+For a list of the supported languages for each model, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 ## Select the region
@@ -198,7 +198,7 @@ var params = TranscriptOptionalParams.builder()
 
 ## Automatic language detection
 
-Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/getting-started/supported-languages).
 
 To reliably identify the dominant language, the file must contain **at least 50 seconds** of spoken audio.
 
@@ -265,7 +265,7 @@ var params = TranscriptOptionalParams.builder()
 
   
 
-To see all supported languages and their codes, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+To see all supported languages and their codes, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 

--- a/fern/pages/05-guides/sdks/java/java-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/java/java-audio-intelligence.mdx
@@ -205,7 +205,7 @@ Here are a few examples of what you can detect:
 For the full list of entities that you can detect, see [Supported entities](#supported-entities).
 
 <Tip title="Supported languages">
-Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Entity Detection is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 **Quickstart**
@@ -345,7 +345,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
-PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+PII Redaction is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 <Warning title="Redacted properties">

--- a/fern/pages/05-guides/sdks/js/js-async.mdx
+++ b/fern/pages/05-guides/sdks/js/js-async.mdx
@@ -143,7 +143,7 @@ const params = {
 
   
 
-For a list of the supported languages for each model, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+For a list of the supported languages for each model, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 ## Select the region
@@ -198,7 +198,7 @@ const params = {
 
 ## Automatic language detection
 
-Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/getting-started/supported-languages).
 
 To reliably identify the dominant language, the file must contain **at least 50 seconds** of spoken audio.
 
@@ -268,7 +268,7 @@ const params = {
 
   
 
-To see all supported languages and their codes, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+To see all supported languages and their codes, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 

--- a/fern/pages/05-guides/sdks/js/js-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/js/js-audio-intelligence.mdx
@@ -226,7 +226,7 @@ Here are a few examples of what you can detect:
 For the full list of entities that you can detect, see [Supported entities](#supported-entities).
 
 <Tip title="Supported languages">
-Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Entity Detection is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 **Quickstart**
@@ -359,7 +359,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
-PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+PII Redaction is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 <Warning title="Redacted properties">

--- a/fern/pages/05-guides/sdks/python/python-async.mdx
+++ b/fern/pages/05-guides/sdks/python/python-async.mdx
@@ -133,7 +133,7 @@ transcriber = aai.Transcriber(config=config)
 
   
 
-For a list of the supported languages for each model, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+For a list of the supported languages for each model, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 ## Select the region
@@ -185,7 +185,7 @@ transcriber = aai.Transcriber(config=config)
 
 ## Automatic language detection
 
-Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/getting-started/supported-languages).
 
 To reliably identify the dominant language, the file must contain **at least 50 seconds** of spoken audio.
 
@@ -250,7 +250,7 @@ config = aai.TranscriptionConfig(language_code="es")
 
   
 
-To see all supported languages and their codes, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+To see all supported languages and their codes, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 

--- a/fern/pages/05-guides/sdks/python/python-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/python/python-audio-intelligence.mdx
@@ -183,7 +183,7 @@ Here are a few examples of what you can detect:
 For the full list of entities that you can detect, see [Supported entities](#supported-entities).
 
 <Tip title="Supported languages">
-Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Entity Detection is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 **Quickstart**
@@ -293,7 +293,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
-PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+PII Redaction is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 <Warning title="Redacted properties">

--- a/fern/pages/05-guides/sdks/ruby/ruby-async.mdx
+++ b/fern/pages/05-guides/sdks/ruby/ruby-async.mdx
@@ -129,7 +129,7 @@ transcript = client.transcripts.transcribe(
 
   
 
-For a list of the supported languages for each model, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+For a list of the supported languages for each model, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 ## Select the region
@@ -182,7 +182,7 @@ transcript = client.transcripts.transcribe(
 
 ## Automatic language detection
 
-Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/getting-started/supported-languages).
 
 To reliably identify the dominant language, the file must contain **at least 50 seconds** of spoken audio.
 
@@ -252,7 +252,7 @@ transcript = client.transcripts.transcribe(
 
   
 
-To see all supported languages and their codes, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+To see all supported languages and their codes, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 

--- a/fern/pages/05-guides/sdks/ruby/ruby-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/ruby/ruby-audio-intelligence.mdx
@@ -191,7 +191,7 @@ Here are a few examples of what you can detect:
 For the full list of entities that you can detect, see [Supported entities](#supported-entities).
 
 <Tip title="Supported languages">
-Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Entity Detection is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 **Quickstart**
@@ -314,7 +314,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
-PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+PII Redaction is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 <Warning title="Redacted properties">

--- a/fern/pages/05-guides/sdks/template.mdx
+++ b/fern/pages/05-guides/sdks/template.mdx
@@ -528,7 +528,7 @@ transcript = client.transcripts.transcribe(
   </Tab>
 </Tabs>
 
-For a list of the supported languages for each model, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+For a list of the supported languages for each model, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 ## Select the region
@@ -701,7 +701,7 @@ transcript = client.transcripts.transcribe(
 
 ## Automatic language detection
 
-Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Identify the dominant language spoken in an audio file and use it during the transcription. Enable it to detect any of the [supported languages](/docs/getting-started/supported-languages).
 
 To reliably identify the dominant language, the file must contain **at least 50 seconds** of spoken audio.
 
@@ -954,7 +954,7 @@ transcript = client.transcripts.transcribe(
   </Tab>
 </Tabs>
 
-To see all supported languages and their codes, see [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+To see all supported languages and their codes, see [Supported languages](/docs/getting-started/supported-languages).
 
 
 
@@ -3766,7 +3766,7 @@ Here are a few examples of what you can detect:
 For the full list of entities that you can detect, see [Supported entities](#supported-entities).
 
 <Tip title="Supported languages">
-Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+Entity Detection is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 **Quickstart**
@@ -4228,7 +4228,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
-PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
+PII Redaction is available in multiple languages. See [Supported languages](/docs/getting-started/supported-languages).
 </Tip>
 
 <Warning title="Redacted properties">

--- a/openapi.yml
+++ b/openapi.yml
@@ -594,6 +594,7 @@ paths:
       summary: Create temporary authentication token for Streaming STT
       description: |
         <Warning>Streaming Speech-to-Text is currently not available on the EU endpoint.</Warning>
+        <Note>Any usage associated with a temporary token will be attributed to the API key that generated it.</Note>
         Create a temporary authentication token for Streaming Speech-to-Text
       operationId: createTemporaryToken
       x-fern-sdk-group-name: realtime


### PR DESCRIPTION
This PR will move the supported languages page back to the getting started section like before. 

Customers have bookmarked the old link https://www.assemblyai.com/docs/getting-started/supported-languages
which now leads to a 404. 

Some additional context on why Supported Languages was moved to the Getting Started Section:
https://assemblyai.slack.com/archives/C058SSDGFDK/p1721121507656189