### PR TITLE
fix: broken links errors

### DIFF
--- a/cookbook-master/core-transcription/migration_guides/oai_to_aai.ipynb
+++ b/cookbook-master/core-transcription/migration_guides/oai_to_aai.ipynb
@@ -78,7 +78,7 @@
         "\n",
         "When migrating from OpenAI to AssemblyAI, you'll first need to handle authentication and SDK setup:\n",
         "\n",
-        "Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/dashboard/login) \\\n",
+        "Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys) \\\n",
         "To follow this guide, install AssemblyAI's Python SDK by typing this code into your terminal: `pip install assemblyai` \\\n",
         "Check our [documentation for the full list of available SDKs](https://www.assemblyai.com/docs/#quickstart)\n",
         "\n",

--- a/fern/cookbooks/core-transcription/migration_guides/aws_to_aai.mdx
+++ b/fern/cookbooks/core-transcription/migration_guides/aws_to_aai.mdx
@@ -34,7 +34,7 @@ Below is a side-by-side comparison of a basic snippet to transcribe a file by AW
 
 When migrating from AWS to AssemblyAI, you'll first need to handle authentication and SDK setup:
 
-Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/dashboard/login) \
+Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys) \
 Check our [documentation for the full list of available SDKs](https://www.assemblyai.com/docs/#quickstart)
 
 Things to know:

--- a/fern/cookbooks/core-transcription/migration_guides/dg_to_aai.mdx
+++ b/fern/cookbooks/core-transcription/migration_guides/dg_to_aai.mdx
@@ -25,7 +25,7 @@ Before we begin, make sure you have an AssemblyAI account and an API key. You ca
 
 When migrating from Deepgram to AssemblyAI, you'll first need to handle authentication and SDK setup:
 
-Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/dashboard/login) \
+Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys) \
 To follow this guide, install AssemblyAI's Python SDK by typing this code into your terminal: `pip install assemblyai` \
 Check our [documentation for the full list of available SDKs](https://www.assemblyai.com/docs/#quickstart)
 

--- a/fern/cookbooks/core-transcription/migration_guides/google_to_aai.mdx
+++ b/fern/cookbooks/core-transcription/migration_guides/google_to_aai.mdx
@@ -37,7 +37,7 @@ Below is a side-by-side comparison of a basic snippet to transcribe a file by Go
 
 When migrating from Google Speech-to-Text to AssemblyAI, you'll first need to handle authentication and SDK setup:
 
-Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/dashboard/login). \
+Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys). \
 Check our [documentation for the full list of available SDKs](https://www.assemblyai.com/docs/#quickstart).
 
 Things to know:

--- a/fern/cookbooks/core-transcription/migration_guides/oai_to_aai.mdx
+++ b/fern/cookbooks/core-transcription/migration_guides/oai_to_aai.mdx
@@ -44,7 +44,7 @@ Here are helpful things to know about our `transcribe` method:
 
 When migrating from OpenAI to AssemblyAI, you'll first need to handle authentication and SDK setup:
 
-Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/dashboard/login) \
+Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys) \
 To follow this guide, install AssemblyAI's Python SDK by typing this code into your terminal: `pip install assemblyai` \
 Check our [documentation for the full list of available SDKs](https://www.assemblyai.com/docs/#quickstart)
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -106,7 +106,7 @@ navigation:
               - page: Identifying Hate Speech in Audio or Video Files
                 path: pages/05-guides/identifying-hate-speech-in-audio-or-video-files.mdx
                 hidden: true
-              - page: How to Identify Highlights in Audio or Video Files
+              - page: Identifying Highlights in Audio or Video Files
                 path: pages/05-guides/identifying-highlights-in-audio-or-video-files.mdx
                 hidden: true
               - page: Identifying Speakers in Audio Recordings

--- a/fern/pages/01-getting-started/transcribe-an-audio-file.mdx
+++ b/fern/pages/01-getting-started/transcribe-an-audio-file.mdx
@@ -373,8 +373,7 @@ In this step, you 'll create an SDK client and configure it to use your API key.
 <Steps>
 <Step>
 
-Browse to <a href="https://www.assemblyai.com/app/account" target="_blank">Account</a>, and then click the text under **Your API key** to copy it.
-
+Browse to <a href="https://www.assemblyai.com/app/api-keys" target="_blank">API Keys</a> in your dashboard, and then copy your API key.
 </Step>
 <Step>
 

--- a/fern/pages/01-getting-started/transcribe-an-audio-file/csharp.mdx
+++ b/fern/pages/01-getting-started/transcribe-an-audio-file/csharp.mdx
@@ -151,9 +151,8 @@ In this step you'll set the base URL and configure your API key.
 
 <Steps>
   <Step>
-    Browse to <a href="https://www.assemblyai.com/app/account" target="_blank">Account</a>, and then click the text under **Your API key** to copy it.
+    Browse to <a href="https://www.assemblyai.com/app/api-keys" target="_blank">API Keys</a> in your dashboard, and then copy your API key.
   </Step>
-
   <Step>
     Set the base url.
     ```C#
@@ -220,7 +219,7 @@ In this step, you'll submit the audio file for transcription and wait until it's
     ```
 
     <Tip title="Select the speech model">
-      You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio#select-the-speech-model-with-best-and-nano).
+      You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano).
     </Tip>
   </Step>
   <Step>

--- a/fern/pages/01-getting-started/transcribe-an-audio-file/php.mdx
+++ b/fern/pages/01-getting-started/transcribe-an-audio-file/php.mdx
@@ -123,9 +123,8 @@ In this step you'll set the base URL and configure your API key.
 
 <Steps>
   <Step>
-    Browse to <a href="https://www.assemblyai.com/app/account" target="_blank">Account</a>, and then click the text under **Your API key** to copy it.
+    Browse to <a href="https://www.assemblyai.com/app/api-keys" target="_blank">API Keys</a> in your dashboard, and then copy your API key.
   </Step>
-
   <Step>
     Set the base URL and set your headers. Replace `YOUR_API_KEY` with your copied API key.
     ```php
@@ -196,7 +195,7 @@ In this step, you'll submit the audio file for transcription and wait until it c
     ```
 
     <Tip title="Select the speech model">
-      You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio#select-the-speech-model-with-best-and-nano).
+      You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano).
     </Tip>
   </Step>
   <Step>

--- a/fern/pages/01-getting-started/transcribe-an-audio-file/python.mdx
+++ b/fern/pages/01-getting-started/transcribe-an-audio-file/python.mdx
@@ -143,7 +143,7 @@ To complete this tutorial, you need:
 
       <Steps>
         <Step>
-          Browse to <a href="https://www.assemblyai.com/app/account" target="_blank">Account</a>, and then click the text under **Your API key** to copy it.
+          Browse to <a href="https://www.assemblyai.com/app/api-keys" target="_blank">API Keys</a> in your dashboard, and then copy your API key.
         </Step>
 
         <Step>
@@ -165,7 +165,7 @@ To complete this tutorial, you need:
 
       <Steps>
         <Step>
-          Browse to <a href="https://www.assemblyai.com/app/account" target="_blank">Account</a>, and then click the text under **Your API key** to copy it.
+          Browse to <a href="https://www.assemblyai.com/app/api-keys" target="_blank">API Keys</a> in your dashboard, and then copy your API key.
         </Step>
 
         <Step>
@@ -219,7 +219,7 @@ In this step, you'll submit the audio file for transcription and wait until it's
         ```
 
         <Tip title="Select the speech model">
-        You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio#select-the-speech-model-with-best-and-nano).
+        You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano).
         </Tip>
       </Step>
       <Step>
@@ -287,7 +287,7 @@ In this step, you'll submit the audio file for transcription and wait until it's
         ```
 
         <Tip title="Select the speech model">
-          You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio#select-the-speech-model-with-best-and-nano).
+          You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano).
         </Tip>
       </Step>
       <Step>

--- a/fern/pages/01-getting-started/transcribe-an-audio-file/ruby.mdx
+++ b/fern/pages/01-getting-started/transcribe-an-audio-file/ruby.mdx
@@ -114,9 +114,8 @@ In this step you'll set the base URL and configure your API key.
 
   <Steps>
     <Step>
-      Browse to <a href="https://www.assemblyai.com/app/account" target="_blank">Account</a>, and then click the text under **Your API key** to copy it.
+      Browse to <a href="https://www.assemblyai.com/app/api-keys" target="_blank">API Keys</a> in your dashboard, and then copy your API key.
     </Step>
-
     <Step>
       Set the base URL and set your headers. Replace `YOUR_API_KEY` with your copied API key.
       ```ruby
@@ -176,7 +175,7 @@ In this step, you'll submit the audio file for transcription and wait until it's
     ```
 
     <Tip title="Select the speech model">
-      You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio#select-the-speech-model-with-best-and-nano).
+      You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano).
     </Tip>
   </Step>
   <Step>

--- a/fern/pages/01-getting-started/transcribe-an-audio-file/typescript.mdx
+++ b/fern/pages/01-getting-started/transcribe-an-audio-file/typescript.mdx
@@ -177,7 +177,7 @@ To complete this tutorial, you need:
 
     <Steps>
       <Step>
-        Browse to <a href="https://www.assemblyai.com/app/account" target="_blank">Account</a>, and then click the text under **Your API key** to copy it.
+        Browse to <a href="https://www.assemblyai.com/app/api-keys" target="_blank">API Keys</a> in your dashboard, and then copy your API key.
       </Step>
 
       <Step>
@@ -199,7 +199,7 @@ To complete this tutorial, you need:
     In this step you'll set the base URL and configure your API key.
       <Steps>
         <Step>
-          Browse to <a href="https://www.assemblyai.com/app/account" target="_blank">Account</a>, and then click the text under **Your API key** to copy it.
+          Browse to <a href="https://www.assemblyai.com/app/api-keys" target="_blank">API Keys</a> in your dashboard, and then copy your API key.
         </Step>
 
         <Step>
@@ -257,7 +257,7 @@ In this step, you'll submit the audio file for transcription and wait until it's
         ```
 
         <Tip title="Select the speech model">
-        You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio#select-the-speech-model-with-best-and-nano).
+        You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano).
         </Tip>
       </Step>
       <Step>
@@ -326,7 +326,7 @@ In this step, you'll submit the audio file for transcription and wait until it's
           </Note>
 
           <Tip title="Select the speech model">
-            You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio#select-the-speech-model-with-best-and-nano).
+            You can select the class of models to use in order to make cost-performance tradeoffs best suited for your application. See [Select the speech model](/docs/speech-to-text/pre-recorded-audio/select-the-speech-model-with-best-and-nano).
           </Tip>
         </Step>
         <Step>

--- a/fern/pages/01-getting-started/transcribe-streaming-audio-from-a-microphone/csharp.mdx
+++ b/fern/pages/01-getting-started/transcribe-streaming-audio-from-a-microphone/csharp.mdx
@@ -316,8 +316,7 @@ using System.Threading.Tasks;
 
 <Step>
 
-Browse to <a href="https://www.assemblyai.com/app/account" target="_blank">Account</a>, and then click the text under **Your API key** to copy it.
-
+Browse to <a href="https://www.assemblyai.com/app/api-keys" target="_blank">API Keys</a> in your dashboard, and then copy your API key.
 </Step>
 
 <Step>

--- a/fern/pages/01-getting-started/transcribe-streaming-audio-from-a-microphone/python.mdx
+++ b/fern/pages/01-getting-started/transcribe-streaming-audio-from-a-microphone/python.mdx
@@ -213,7 +213,7 @@ In this step, you'll configure your API key to authenticate with AssemblyAI.
 <Steps>
 <Step>
 
-Browse to <a href="https://www.assemblyai.com/app" target="_blank">Account</a>, and then click **Copy API key** under **Copy your API key**.
+Browse to <a href="https://www.assemblyai.com/app/api-keys" target="_blank">API Keys</a> in your dashboard, and then copy your API key.
 
 </Step>
 <Step>

--- a/fern/pages/01-getting-started/transcribe-streaming-audio-from-a-microphone/ruby.mdx
+++ b/fern/pages/01-getting-started/transcribe-streaming-audio-from-a-microphone/ruby.mdx
@@ -206,11 +206,9 @@ gem install websocket-client-simple
 In this step, you’ll configure your API key to authenticate with AssemblyAI.
 
 <Steps>
-<Step>
-
-Browse to <a href="https://www.assemblyai.com/app/account" target="_blank">Account</a>, and then click **Copy API key** under **Your API key** to copy it.
-
-</Step>
+  <Step>
+    Browse to <a href="https://www.assemblyai.com/app/api-keys" target="_blank">API Keys</a> in your dashboard, and then copy your API key.
+  </Step>
 <Step>
 
 Store your API key in a variable. Replace YOUR_API_KEY with your copied API key.

--- a/fern/pages/01-getting-started/transcribe-streaming-audio-from-a-microphone/typescript.mdx
+++ b/fern/pages/01-getting-started/transcribe-streaming-audio-from-a-microphone/typescript.mdx
@@ -240,8 +240,7 @@ In this step, you'll create an SDK client and configure it to use your API key.
 <Steps>
 <Step>
 
-Browse to <a href="https://www.assemblyai.com/app/account" target="_blank">Account</a>, and then click the text under **Your API key** to copy it.
-
+Browse to <a href="https://www.assemblyai.com/app/api-keys" target="_blank">API Keys</a> in your dashboard, and then copy your API key.
 </Step>
 <Step>
 <Tabs groupId="language">

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/speaker-diarization.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/speaker-diarization.mdx
@@ -431,7 +431,7 @@ curl https://api.assemblyai.com/v2/transcript \
 | Key                | Type    | Description                                        |
 | ------------------ | ------- | -------------------------------------------------- |
 | `speaker_labels`   | boolean | Enable Speaker Diarization.                        |
-| `speaker_expected` | number  | [Set number of speakers](#set-number-of-speakers). |
+| `speaker_expected` | number  | Set number of speakers. |
 
 ### Response
 

--- a/fern/pages/05-guides/cookbooks/core-transcription/aws_to_aai.mdx
+++ b/fern/pages/05-guides/cookbooks/core-transcription/aws_to_aai.mdx
@@ -113,7 +113,7 @@ transcriber = aai.Transcriber()
 
 When migrating from AWS to AssemblyAI, you'll first need to handle authentication and SDK setup:
 
-Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/dashboard/login) \
+Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys) \
 Check our [documentation for the full list of available SDKs](https://www.assemblyai.com/docs/#quickstart)
 
 Things to know:

--- a/fern/pages/05-guides/cookbooks/core-transcription/dg_to_aai.mdx
+++ b/fern/pages/05-guides/cookbooks/core-transcription/dg_to_aai.mdx
@@ -184,7 +184,7 @@ transcriber = aai.Transcriber()
 
 When migrating from Deepgram to AssemblyAI, you'll first need to handle authentication and SDK setup:
 
-Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/dashboard/login) \
+Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys) \
 To follow this guide, install AssemblyAI's Python SDK by typing this code into your terminal: `pip install assemblyai` \
 Check our [documentation for the full list of available SDKs](https://www.assemblyai.com/docs/#quickstart)
 

--- a/fern/pages/05-guides/cookbooks/core-transcription/google_to_aai.mdx
+++ b/fern/pages/05-guides/cookbooks/core-transcription/google_to_aai.mdx
@@ -97,7 +97,7 @@ transcriber = aai.Transcriber()
 
 When migrating from Google Speech-to-Text to AssemblyAI, you'll first need to handle authentication and SDK setup:
 
-Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/dashboard/login). \
+Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys). \
 Check our [documentation for the full list of available SDKs](https://www.assemblyai.com/docs/#quickstart).
 
 Things to know:

--- a/fern/pages/05-guides/cookbooks/core-transcription/how_to_use_the_eu_endpoint.mdx
+++ b/fern/pages/05-guides/cookbooks/core-transcription/how_to_use_the_eu_endpoint.mdx
@@ -132,5 +132,5 @@ func main() {
 }
 ```
 
-If you encounter any issues or have any questions, reach out to our [Support team.](https://support.assemblyai.com/)
+If you encounter any issues or have any questions, reach out to our [Support team.](https://www.assemblyai.com/contact/support)
 

--- a/fern/pages/05-guides/cookbooks/core-transcription/oai_to_aai.mdx
+++ b/fern/pages/05-guides/cookbooks/core-transcription/oai_to_aai.mdx
@@ -89,7 +89,7 @@ transcriber = aai.Transcriber()
 
 When migrating from OpenAI to AssemblyAI, you'll first need to handle authentication and SDK setup:
 
-Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/dashboard/login) \
+Get your API key from your [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys) \
 To follow this guide, install AssemblyAI's Python SDK by typing this code into your terminal: `pip install assemblyai` \
 Check our [documentation for the full list of available SDKs](https://www.assemblyai.com/docs/#quickstart)
 

--- a/fern/pages/05-guides/sdks/csharp/csharp-async.mdx
+++ b/fern/pages/05-guides/sdks/csharp/csharp-async.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'C# SDK Reference - Pre-recorded audio'
+title: 'C# SDK Reference'
 ---
 
 # Pre-recorded audio

--- a/fern/pages/05-guides/sdks/csharp/csharp-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/csharp/csharp-audio-intelligence.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'C# SDK Reference Audio Intelligence'
+title: 'C# SDK Reference'
 ---
 
 # Audio Intelligence

--- a/fern/pages/05-guides/sdks/csharp/csharp-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/csharp/csharp-audio-intelligence.mdx
@@ -55,7 +55,7 @@ foreach (var chapter in transcript.Chapters!)
 ```
 
 <Tip title="Auto Chapters Using LeMUR">
-Check out this cookbook [Creating Chapter Summaries](https://github.com/AssemblyAI/cookbook/blob/master/lemur/input-text-chapters.ipynb) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
+Check out this cookbook [Creating Chapter Summaries](/docs/guides/input-text-chapters) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
 </Tip>
 
 For the full API reference, see the [API reference section on the Auto Chapters page](/docs/audio-intelligence/auto-chapters#api-reference).
@@ -192,7 +192,7 @@ Here are a few examples of what you can detect:
 - Medical data
 - Social security numbers
 
-For the full list of entities that you can detect, see [Supported entities](#supported-entities).
+For the full list of entities that you can detect, see [Supported entities](/docs/audio-intelligence/entity-detection#supported-entities).
 
 <Tip title="Supported languages">
 Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -306,7 +306,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 - With `hash` substitution: `Hi, my name is ####!`
 - With `entity_name` substitution: `Hi, my name is [PERSON_NAME]!`
 
-You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
+You can also [Create redacted audio files](/docs/audio-intelligence/pii-redaction#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
 PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -325,7 +325,7 @@ PII only redacts words in the `text` property. Properties from other features ma
 parameters.
 
 Use `RedactPiiPolicies` to specify the information you want to
-redact. For the full list of policies, see [PII policies](#pii-policies).
+redact. For the full list of policies, see [PII policies](/docs/audio-intelligence/pii-redaction#pii-policies).
 
 ```csharp {10-15}
 using AssemblyAI;
@@ -473,7 +473,7 @@ Timestamp: 250 - 6350
 ...
 ```
 <Tip title="Sentiment Analysis Using LeMUR">
-Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](https://github.com/AssemblyAI/cookbook/blob/master/lemur/call-sentiment-analysis.ipynb) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
+Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](/docs/guides/call-sentiment-analysis) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
 </Tip>
 
 **Add speaker labels to sentiments**
@@ -511,7 +511,7 @@ For the full API reference and FAQs, refer to the [full Sentiment Analysis page]
 
 Distill important information by summarizing your audio files.
 
-The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](#summary-models) and [Summary types](#summary-types).
+The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](/docs/audio-intelligence/summarization#summary-models) and [Summary types](/docs/audio-intelligence/summarization#summary-types).
 
 <Warning title="Summarization and Auto Chapters">
 You can only enable one of the Summarization and [Auto Chapters](/docs/audio-intelligence/auto-chapters) models in the same transcription.
@@ -623,7 +623,7 @@ Audio is 93.78% relevant to Home&Garden>IndoorEnvironmentalQuality
 ```
 
 <Tip title="Topic Detection Using LeMUR">
-Check out this cookbook [Custom Topic Tags](https://github.com/AssemblyAI/cookbook/blob/master/lemur/custom-topic-tags.ipynb) for an example of how to leverage LeMUR for custom topic detection.
+Check out this cookbook [Custom Topic Tags](/docs/guides/custom-topic-tags) for an example of how to leverage LeMUR for custom topic detection.
 </Tip>
 
 

--- a/fern/pages/05-guides/sdks/csharp/csharp-lemur.mdx
+++ b/fern/pages/05-guides/sdks/csharp/csharp-lemur.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'C# SDK Reference LeMUR'
+title: 'C# SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/csharp/csharp-streaming.mdx
+++ b/fern/pages/05-guides/sdks/csharp/csharp-streaming.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'C# SDK Reference Streaming'
+title: 'C# SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/go/go-async.mdx
+++ b/fern/pages/05-guides/sdks/go/go-async.mdx
@@ -254,7 +254,7 @@ transcript, _ := client.Transcripts.TranscribeFromURL(ctx, audioURL, &aai.Transc
   
 
 <Tip title="Fallback to a default language">
-For a workflow that resubmits a transcription request using a default language if the threshold is not reached, see [this cookbook](https://github.com/AssemblyAI/cookbook/blob/master/core-transcription/automatic-language-detection-route-default-language-python.ipynb).
+For a workflow that resubmits a transcription request using a default language if the threshold is not reached, see [this cookbook](/docs/guides/automatic-language-detection-route-default-language).
 </Tip>
 
 

--- a/fern/pages/05-guides/sdks/go/go-async.mdx
+++ b/fern/pages/05-guides/sdks/go/go-async.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Go SDK Reference - Pre-recorded audio'
+title: 'Go SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/go/go-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/go/go-audio-intelligence.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Go Audio Intelligence'
+title: 'Go SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/go/go-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/go/go-audio-intelligence.mdx
@@ -69,7 +69,7 @@ func main() {
 ```
 
 <Tip title="Auto Chapters Using LeMUR">
-Check out this cookbook [Creating Chapter Summaries](https://github.com/AssemblyAI/cookbook/blob/master/lemur/input-text-chapters.ipynb) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
+Check out this cookbook [Creating Chapter Summaries](/docs/guides/input-text-chapters) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
 </Tip>
 
 For the full API reference, see the [API reference section on the Auto Chapters page](/docs/audio-intelligence/auto-chapters#api-reference).
@@ -215,7 +215,7 @@ Here are a few examples of what you can detect:
 - Medical data
 - Social security numbers
 
-For the full list of entities that you can detect, see [Supported entities](#supported-entities).
+For the full list of entities that you can detect, see [Supported entities](/docs/audio-intelligence/entity-detection#supported-entities).
 
 <Tip title="Supported languages">
 Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -353,7 +353,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 - With `hash` substitution: `Hi, my name is ####!`
 - With `entity_name` substitution: `Hi, my name is [PERSON_NAME]!`
 
-You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
+You can also [Create redacted audio files](/docs/audio-intelligence/pii-redaction#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
 PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -372,7 +372,7 @@ PII only redacts words in the `text` property. Properties from other features ma
 parameters.
 
 Use `RedactPIIPolicies` to specify the information you want to
-redact. For the full list of policies, see [PII policies](#pii-policies).
+redact. For the full list of policies, see [PII policies](/docs/audio-intelligence/pii-redaction#pii-policies).
 
 ```go {19-21}
 package main
@@ -523,7 +523,7 @@ Timestamp: 250 - 6350
 ...
 ```
 <Tip title="Sentiment Analysis Using LeMUR">
-Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](https://github.com/AssemblyAI/cookbook/blob/master/lemur/call-sentiment-analysis.ipynb) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
+Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](/docs/guides/call-sentiment-analysis) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
 </Tip>
 
 **Add speaker labels to sentiments**
@@ -555,7 +555,7 @@ For the full API reference and FAQs, refer to the [full Sentiment Analysis page]
 
 Distill important information by summarizing your audio files.
 
-The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](#summary-models) and [Summary types](#summary-types).
+The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](/docs/audio-intelligence/summarization#summary-models) and [Summary types](/docs/audio-intelligence/summarization#summary-types).
 
 <Warning title="Summarization and Auto Chapters">
 You can only enable one of the Summarization and [Auto Chapters](/docs/audio-intelligence/auto-chapters) models in the same transcription.
@@ -685,7 +685,7 @@ Audio is 93.78% relevant to Home&Garden>IndoorEnvironmentalQuality
 ```
 
 <Tip title="Topic Detection Using LeMUR">
-Check out this cookbook [Custom Topic Tags](https://github.com/AssemblyAI/cookbook/blob/master/lemur/custom-topic-tags.ipynb) for an example of how to leverage LeMUR for custom topic detection.
+Check out this cookbook [Custom Topic Tags](/docs/guides/custom-topic-tags) for an example of how to leverage LeMUR for custom topic detection.
 </Tip>
 
 

--- a/fern/pages/05-guides/sdks/go/go-lemur.mdx
+++ b/fern/pages/05-guides/sdks/go/go-lemur.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Go LeMUR'
+title: 'Go SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/go/go-streaming.mdx
+++ b/fern/pages/05-guides/sdks/go/go-streaming.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Go Streaming'
+title: 'Go SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/java/java-async.mdx
+++ b/fern/pages/05-guides/sdks/java/java-async.mdx
@@ -244,7 +244,7 @@ var params = TranscriptOptionalParams.builder()
   
 
 <Tip title="Fallback to a default language">
-For a workflow that resubmits a transcription request using a default language if the threshold is not reached, see [this cookbook](https://github.com/AssemblyAI/cookbook/blob/master/core-transcription/automatic-language-detection-route-default-language-python.ipynb).
+For a workflow that resubmits a transcription request using a default language if the threshold is not reached, see [this cookbook](/docs/guides/automatic-language-detection-route-default-language).
 </Tip>
 
 

--- a/fern/pages/05-guides/sdks/java/java-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/java/java-audio-intelligence.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Java Audio Intelligence'
+title: 'Java SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/java/java-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/java/java-audio-intelligence.mdx
@@ -66,7 +66,7 @@ public final class App {
 ```
 
 <Tip title="Auto Chapters Using LeMUR">
-Check out this cookbook [Creating Chapter Summaries](https://github.com/AssemblyAI/cookbook/blob/master/lemur/input-text-chapters.ipynb) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
+Check out this cookbook [Creating Chapter Summaries](/docs/guides/input-text-chapters) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
 </Tip>
 
 For the full API reference, see the [API reference section on the Auto Chapters page](/docs/audio-intelligence/auto-chapters#api-reference).
@@ -202,7 +202,7 @@ Here are a few examples of what you can detect:
 - Medical data
 - Social security numbers
 
-For the full list of entities that you can detect, see [Supported entities](#supported-entities).
+For the full list of entities that you can detect, see [Supported entities](/docs/audio-intelligence/entity-detection#supported-entities).
 
 <Tip title="Supported languages">
 Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -342,7 +342,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 - With `hash` substitution: `Hi, my name is ####!`
 - With `entity_name` substitution: `Hi, my name is [PERSON_NAME]!`
 
-You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
+You can also [Create redacted audio files](/docs/audio-intelligence/pii-redaction#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
 PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -361,7 +361,7 @@ PII only redacts words in the `text` property. Properties from other features ma
 config.
 
 Use `redactPiiPolicies` to specify the information you want to
-redact. For the full list of policies, see [PII policies](#pii-policies).
+redact. For the full list of policies, see [PII policies](/docs/audio-intelligence/pii-redaction#pii-policies).
 
 ```java {15-17}
 
@@ -461,7 +461,7 @@ Timestamp: 250 - 6350
 ...
 ```
 <Tip title="Sentiment Analysis Using LeMUR">
-Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](https://github.com/AssemblyAI/cookbook/blob/master/lemur/call-sentiment-analysis.ipynb) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
+Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](/docs/guides/call-sentiment-analysis) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
 </Tip>
 
 **Add speaker labels to sentiments**
@@ -495,7 +495,7 @@ For the full API reference and FAQs, refer to the [full Sentiment Analysis page]
 
 Distill important information by summarizing your audio files.
 
-The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](#summary-models) and [Summary types](#summary-types).
+The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](/docs/audio-intelligence/summarization#summary-models) and [Summary types](/docs/audio-intelligence/summarization#summary-types).
 
 <Warning title="Summarization and Auto Chapters">
 You can only enable one of the Summarization and [Auto Chapters](/docs/audio-intelligence/auto-chapters) models in the same transcription.
@@ -629,7 +629,7 @@ Audio is 93.78% relevant to Home&Garden>IndoorEnvironmentalQuality
 ```
 
 <Tip title="Topic Detection Using LeMUR">
-Check out this cookbook [Custom Topic Tags](https://github.com/AssemblyAI/cookbook/blob/master/lemur/custom-topic-tags.ipynb) for an example of how to leverage LeMUR for custom topic detection.
+Check out this cookbook [Custom Topic Tags](/docs/guides/custom-topic-tags) for an example of how to leverage LeMUR for custom topic detection.
 </Tip>
 
 

--- a/fern/pages/05-guides/sdks/java/java-lemur.mdx
+++ b/fern/pages/05-guides/sdks/java/java-lemur.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Java LeMUR'
+title: 'Java SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/java/java-streaming.mdx
+++ b/fern/pages/05-guides/sdks/java/java-streaming.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Java Streaming'
+title: 'Java SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/js/js-async.mdx
+++ b/fern/pages/05-guides/sdks/js/js-async.mdx
@@ -246,7 +246,7 @@ const params = {
   
 
 <Tip title="Fallback to a default language">
-For a workflow that resubmits a transcription request using a default language if the threshold is not reached, see [this cookbook](https://github.com/AssemblyAI/cookbook/blob/master/core-transcription/automatic-language-detection-route-default-language-python.ipynb).
+For a workflow that resubmits a transcription request using a default language if the threshold is not reached, see [this cookbook](/docs/guides/automatic-language-detection-route-default-language).
 </Tip>
 
 

--- a/fern/pages/05-guides/sdks/js/js-async.mdx
+++ b/fern/pages/05-guides/sdks/js/js-async.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'JavaScript SDK - Pre-recorded audio'
+title: 'JavaScript SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/js/js-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/js/js-audio-intelligence.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'JavaScript SDK - Audio Intelligence'
+title: 'JavaScript SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/js/js-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/js/js-audio-intelligence.mdx
@@ -64,7 +64,7 @@ run()
 ```
 
 <Tip title="Auto Chapters Using LeMUR">
-Check out this cookbook [Creating Chapter Summaries](https://github.com/AssemblyAI/cookbook/blob/master/lemur/input-text-chapters.ipynb) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
+Check out this cookbook [Creating Chapter Summaries](/docs/guides/input-text-chapters) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
 </Tip>
 
 For the full API reference, see the [API reference section on the Auto Chapters page](/docs/audio-intelligence/auto-chapters#api-reference).
@@ -223,7 +223,7 @@ Here are a few examples of what you can detect:
 - Medical data
 - Social security numbers
 
-For the full list of entities that you can detect, see [Supported entities](#supported-entities).
+For the full list of entities that you can detect, see [Supported entities](/docs/audio-intelligence/entity-detection#supported-entities).
 
 <Tip title="Supported languages">
 Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -356,7 +356,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 - With `hash` substitution: `Hi, my name is ####!`
 - With `entity_name` substitution: `Hi, my name is [PERSON_NAME]!`
 
-You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
+You can also [Create redacted audio files](/docs/audio-intelligence/pii-redaction#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
 PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -375,7 +375,7 @@ PII only redacts words in the `text` property. Properties from other features ma
 config.
 
 Use `redact_pii_policies` to specify the information you want to
-redact. For the full list of policies, see [PII policies](#pii-policies).
+redact. For the full list of policies, see [PII policies](/docs/audio-intelligence/pii-redaction#pii-policies).
 
 ```ts {13-15}
 import { AssemblyAI } from 'assemblyai'
@@ -538,7 +538,7 @@ Timestamp: 250 - 6350
 ...
 ```
 <Tip title="Sentiment Analysis Using LeMUR">
-Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](https://github.com/AssemblyAI/cookbook/blob/master/lemur/call-sentiment-analysis.ipynb) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
+Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](/docs/guides/call-sentiment-analysis) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
 </Tip>
 
 **Add speaker labels to sentiments**
@@ -573,7 +573,7 @@ For the full API reference and FAQs, refer to the [full Sentiment Analysis page]
 
 Distill important information by summarizing your audio files.
 
-The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](#summary-models) and [Summary types](#summary-types).
+The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](/docs/audio-intelligence/summarization#summary-models) and [Summary types](/docs/audio-intelligence/summarization#summary-types).
 
 <Warning title="Summarization and Auto Chapters">
 You can only enable one of the Summarization and [Auto Chapters](/docs/audio-intelligence/auto-chapters) models in the same transcription.
@@ -703,7 +703,7 @@ Audio is 93.78% relevant to Home&Garden>IndoorEnvironmentalQuality
 ```
 
 <Tip title="Topic Detection Using LeMUR">
-Check out this cookbook [Custom Topic Tags](https://github.com/AssemblyAI/cookbook/blob/master/lemur/custom-topic-tags.ipynb) for an example of how to leverage LeMUR for custom topic detection.
+Check out this cookbook [Custom Topic Tags](/docs/guides/custom-topic-tags) for an example of how to leverage LeMUR for custom topic detection.
 </Tip>
 
 

--- a/fern/pages/05-guides/sdks/js/js-lemur.mdx
+++ b/fern/pages/05-guides/sdks/js/js-lemur.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'JavaScript SDK - LeMUR'
+title: 'JavaScript SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/js/js-streaming.mdx
+++ b/fern/pages/05-guides/sdks/js/js-streaming.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'JavaScript SDK - Streaming'
+title: 'JavaScript SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/python/python-async.mdx
+++ b/fern/pages/05-guides/sdks/python/python-async.mdx
@@ -231,7 +231,7 @@ config = aai.TranscriptionConfig(
   
 
 <Tip title="Fallback to a default language">
-For a workflow that resubmits a transcription request using a default language if the threshold is not reached, see [this cookbook](https://github.com/AssemblyAI/cookbook/blob/master/core-transcription/automatic-language-detection-route-default-language-python.ipynb).
+For a workflow that resubmits a transcription request using a default language if the threshold is not reached, see [this cookbook](/docs/guides/automatic-language-detection-route-default-language).
 </Tip>
 
 

--- a/fern/pages/05-guides/sdks/python/python-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/python/python-audio-intelligence.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Python SDK - Audio Intelligence'
+title: 'Python SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/python/python-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/python/python-audio-intelligence.mdx
@@ -54,7 +54,7 @@ for chapter in transcript.chapters:
 ```
 
 <Tip title="Auto Chapters Using LeMUR">
-Check out this cookbook [Creating Chapter Summaries](https://github.com/AssemblyAI/cookbook/blob/master/lemur/input-text-chapters.ipynb) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
+Check out this cookbook [Creating Chapter Summaries](/docs/guides/input-text-chapters) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
 </Tip>
 
 For the full API reference, see the [API reference section on the Auto Chapters page](/docs/audio-intelligence/auto-chapters#api-reference).
@@ -180,7 +180,7 @@ Here are a few examples of what you can detect:
 - Medical data
 - Social security numbers
 
-For the full list of entities that you can detect, see [Supported entities](#supported-entities).
+For the full list of entities that you can detect, see [Supported entities](/docs/audio-intelligence/entity-detection#supported-entities).
 
 <Tip title="Supported languages">
 Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -290,7 +290,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 - With `hash` substitution: `Hi, my name is ####!`
 - With `entity_name` substitution: `Hi, my name is [PERSON_NAME]!`
 
-You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
+You can also [Create redacted audio files](/docs/audio-intelligence/pii-redaction#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
 PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -307,7 +307,7 @@ PII only redacts words in the `text` property. Properties from other features ma
   Enable PII Redaction on the `TranscriptionConfig` using the `set_redact_pii()`
 method.
 
-Set `policies` to specify the information you want to redact. For the full list of policies, see [PII policies](#pii-policies).
+Set `policies` to specify the information you want to redact. For the full list of policies, see [PII policies](/docs/audio-intelligence/pii-redaction#pii-policies).
 
 ```python {8-15}
 import assemblyai as aai
@@ -392,7 +392,7 @@ Timestamp: 250 - 6350
 ...
 ```
 <Tip title="Sentiment Analysis Using LeMUR">
-Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](https://github.com/AssemblyAI/cookbook/blob/master/lemur/call-sentiment-analysis.ipynb) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
+Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](/docs/guides/call-sentiment-analysis) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
 </Tip>
 
 **Add speaker labels to sentiments**
@@ -425,7 +425,7 @@ For the full API reference and FAQs, refer to the [full Sentiment Analysis page]
 
 Distill important information by summarizing your audio files.
 
-The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](#summary-models) and [Summary types](#summary-types).
+The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](/docs/audio-intelligence/summarization#summary-models) and [Summary types](/docs/audio-intelligence/summarization#summary-types).
 
 <Warning title="Summarization and Auto Chapters">
 You can only enable one of the Summarization and [Auto Chapters](/docs/audio-intelligence/auto-chapters) models in the same transcription.
@@ -534,7 +534,7 @@ Audio is 93.78% relevant to Home&Garden>IndoorEnvironmentalQuality
 ```
 
 <Tip title="Topic Detection Using LeMUR">
-Check out this cookbook [Custom Topic Tags](https://github.com/AssemblyAI/cookbook/blob/master/lemur/custom-topic-tags.ipynb) for an example of how to leverage LeMUR for custom topic detection.
+Check out this cookbook [Custom Topic Tags](/docs/guides/custom-topic-tags) for an example of how to leverage LeMUR for custom topic detection.
 </Tip>
 
 

--- a/fern/pages/05-guides/sdks/python/python-lemur.mdx
+++ b/fern/pages/05-guides/sdks/python/python-lemur.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Python SDK - LeMUR'
+title: 'Python SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/python/python-streaming.mdx
+++ b/fern/pages/05-guides/sdks/python/python-streaming.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Python SDK - Streaming'
+title: 'Python SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/ruby/ruby-async.mdx
+++ b/fern/pages/05-guides/sdks/ruby/ruby-async.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Ruby SDK Reference - Pre-recorded audio'
+title: 'Ruby SDK Reference'
 ---
 
 # Pre-recorded audio

--- a/fern/pages/05-guides/sdks/ruby/ruby-async.mdx
+++ b/fern/pages/05-guides/sdks/ruby/ruby-async.mdx
@@ -230,7 +230,7 @@ transcript = client.transcripts.transcribe(
   
 
 <Tip title="Fallback to a default language">
-For a workflow that resubmits a transcription request using a default language if the threshold is not reached, see [this cookbook](https://github.com/AssemblyAI/cookbook/blob/master/core-transcription/automatic-language-detection-route-default-language-python.ipynb).
+For a workflow that resubmits a transcription request using a default language if the threshold is not reached, see [this cookbook](/docs/guides/automatic-language-detection-route-default-language).
 </Tip>
 
 

--- a/fern/pages/05-guides/sdks/ruby/ruby-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/ruby/ruby-audio-intelligence.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Ruby Audio Intelligence'
+title: 'Ruby SDK Reference'
 ---
 
 # Ruby Audio Intelligence

--- a/fern/pages/05-guides/sdks/ruby/ruby-audio-intelligence.mdx
+++ b/fern/pages/05-guides/sdks/ruby/ruby-audio-intelligence.mdx
@@ -42,7 +42,7 @@ end
 ```
 
 <Tip title="Auto Chapters Using LeMUR">
-Check out this cookbook [Creating Chapter Summaries](https://github.com/AssemblyAI/cookbook/blob/master/lemur/input-text-chapters.ipynb) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
+Check out this cookbook [Creating Chapter Summaries](/docs/guides/input-text-chapters) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
 </Tip>
 
 For the full API reference, see the [API reference section on the Auto Chapters page](/docs/audio-intelligence/auto-chapters#api-reference).
@@ -188,7 +188,7 @@ Here are a few examples of what you can detect:
 - Medical data
 - Social security numbers
 
-For the full list of entities that you can detect, see [Supported entities](#supported-entities).
+For the full list of entities that you can detect, see [Supported entities](/docs/audio-intelligence/entity-detection#supported-entities).
 
 <Tip title="Supported languages">
 Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -311,7 +311,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 - With `hash` substitution: `Hi, my name is ####!`
 - With `entity_name` substitution: `Hi, my name is [PERSON_NAME]!`
 
-You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
+You can also [Create redacted audio files](/docs/audio-intelligence/pii-redaction#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
 PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -331,7 +331,7 @@ Enable PII Redaction by setting `redact_pii` to `true` in the transcription
 config.
 
 Use `redact_pii_policies` to specify the information you want to
-redact. For the full list of policies, see [PII policies](#pii-policies).
+redact. For the full list of policies, see [PII policies](/docs/audio-intelligence/pii-redaction#pii-policies).
 
 ```ruby {10-15}
 require 'assemblyai'
@@ -468,7 +468,7 @@ Timestamp: 250 - 6350
 ...
 ```
 <Tip title="Sentiment Analysis Using LeMUR">
-Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](https://github.com/AssemblyAI/cookbook/blob/master/lemur/call-sentiment-analysis.ipynb) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
+Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](/docs/guides/call-sentiment-analysis) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
 </Tip>
 
 **Add speaker labels to sentiments**
@@ -503,7 +503,7 @@ For the full API reference and FAQs, refer to the [full Sentiment Analysis page]
 
 Distill important information by summarizing your audio files.
 
-The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](#summary-models) and [Summary types](#summary-types).
+The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](/docs/audio-intelligence/summarization#summary-models) and [Summary types](/docs/audio-intelligence/summarization#summary-types).
 
 <Warning title="Summarization and Auto Chapters">
 You can only enable one of the Summarization and [Auto Chapters](/docs/audio-intelligence/auto-chapters) models in the same transcription.
@@ -618,7 +618,7 @@ Audio is 93.78% relevant to Home&Garden>IndoorEnvironmentalQuality
 ```
 
 <Tip title="Topic Detection Using LeMUR">
-Check out this cookbook [Custom Topic Tags](https://github.com/AssemblyAI/cookbook/blob/master/lemur/custom-topic-tags.ipynb) for an example of how to leverage LeMUR for custom topic detection.
+Check out this cookbook [Custom Topic Tags](/docs/guides/custom-topic-tags) for an example of how to leverage LeMUR for custom topic detection.
 </Tip>
 
 

--- a/fern/pages/05-guides/sdks/ruby/ruby-lemur.mdx
+++ b/fern/pages/05-guides/sdks/ruby/ruby-lemur.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Ruby SDK - LeMUR'
+title: 'Ruby SDK Reference'
 ---
 
 

--- a/fern/pages/05-guides/sdks/template.mdx
+++ b/fern/pages/05-guides/sdks/template.mdx
@@ -3251,7 +3251,7 @@ end
 ```
 
 <Tip title="Auto Chapters Using LeMUR">
-Check out this cookbook [Creating Chapter Summaries](https://github.com/AssemblyAI/cookbook/blob/master/lemur/input-text-chapters.ipynb) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
+Check out this cookbook [Creating Chapter Summaries](/docs/guides/input-text-chapters) for an example of how to leverage LeMUR's custom text input parameter for chapter summaries.
 </Tip>
 
 For the full API reference, see the [API reference section on the Auto Chapters page](/docs/audio-intelligence/auto-chapters#api-reference).
@@ -3763,7 +3763,7 @@ Here are a few examples of what you can detect:
 - Medical data
 - Social security numbers
 
-For the full list of entities that you can detect, see [Supported entities](#supported-entities).
+For the full list of entities that you can detect, see [Supported entities](/docs/audio-intelligence/entity-detection#supported-entities).
 
 <Tip title="Supported languages">
 Entity Detection is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -4225,7 +4225,7 @@ When you enable the PII Redaction model, your transcript will look like this:
 - With `hash` substitution: `Hi, my name is ####!`
 - With `entity_name` substitution: `Hi, my name is [PERSON_NAME]!`
 
-You can also [Create redacted audio files](#create-redacted-audio-files) to replace sensitive information with a beeping sound.
+You can also [Create redacted audio files](/docs/audio-intelligence/pii-redaction#create-redacted-audio-files) to replace sensitive information with a beeping sound.
 
 <Tip title="Supported languages">
 PII Redaction is available in multiple languages. See [Supported languages](/docs/speech-to-text/pre-recorded-audio/supported-languages).
@@ -4243,7 +4243,7 @@ PII only redacts words in the `text` property. Properties from other features ma
   Enable PII Redaction on the `TranscriptionConfig` using the `set_redact_pii()`
 method.
 
-Set `policies` to specify the information you want to redact. For the full list of policies, see [PII policies](#pii-policies).
+Set `policies` to specify the information you want to redact. For the full list of policies, see [PII policies](/docs/audio-intelligence/pii-redaction#pii-policies).
 
 ```python {8-15}
 import assemblyai as aai
@@ -4276,7 +4276,7 @@ print(transcript.text)
 config.
 
 Use `redact_pii_policies` to specify the information you want to
-redact. For the full list of policies, see [PII policies](#pii-policies).
+redact. For the full list of policies, see [PII policies](/docs/audio-intelligence/pii-redaction#pii-policies).
 
 ```ts {13-15}
 import { AssemblyAI } from 'assemblyai'
@@ -4312,7 +4312,7 @@ run()
 parameters.
 
 Use `RedactPIIPolicies` to specify the information you want to
-redact. For the full list of policies, see [PII policies](#pii-policies).
+redact. For the full list of policies, see [PII policies](/docs/audio-intelligence/pii-redaction#pii-policies).
 
 ```go {19-21}
 package main
@@ -4349,7 +4349,7 @@ func main() {
 config.
 
 Use `redactPiiPolicies` to specify the information you want to
-redact. For the full list of policies, see [PII policies](#pii-policies).
+redact. For the full list of policies, see [PII policies](/docs/audio-intelligence/pii-redaction#pii-policies).
 
 ```java {15-17}
 
@@ -4386,7 +4386,7 @@ public final class App {
 parameters.
 
 Use `RedactPiiPolicies` to specify the information you want to
-redact. For the full list of policies, see [PII policies](#pii-policies).
+redact. For the full list of policies, see [PII policies](/docs/audio-intelligence/pii-redaction#pii-policies).
 
 ```csharp {10-15}
 using AssemblyAI;
@@ -4417,7 +4417,7 @@ Enable PII Redaction by setting `redact_pii` to `true` in the transcription
 config.
 
 Use `redact_pii_policies` to specify the information you want to
-redact. For the full list of policies, see [PII policies](#pii-policies).
+redact. For the full list of policies, see [PII policies](/docs/audio-intelligence/pii-redaction#pii-policies).
 
 ```ruby {10-15}
 require 'assemblyai'
@@ -4868,7 +4868,7 @@ Timestamp: 250 - 6350
 ...
 ```
 <Tip title="Sentiment Analysis Using LeMUR">
-Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](https://github.com/AssemblyAI/cookbook/blob/master/lemur/call-sentiment-analysis.ipynb) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
+Check out this cookbook [LeMUR for Customer Call Sentiment Analysis](/docs/guides/call-sentiment-analysis) for an example of how to leverage LeMUR's QA feature for sentiment analysis.
 </Tip>
 
 **Add speaker labels to sentiments**
@@ -5007,7 +5007,7 @@ For the full API reference and FAQs, refer to the [full Sentiment Analysis page]
 
 Distill important information by summarizing your audio files.
 
-The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](#summary-models) and [Summary types](#summary-types).
+The Summarization model generates a summary of the resulting transcript. You can control the style and format of the summary using [Summary models](/docs/audio-intelligence/summarization#summary-models) and [Summary types](/docs/audio-intelligence/summarization#summary-types).
 
 <Warning title="Summarization and Auto Chapters">
 You can only enable one of the Summarization and [Auto Chapters](/docs/audio-intelligence/auto-chapters) models in the same transcription.
@@ -5506,7 +5506,7 @@ Audio is 93.78% relevant to Home&Garden>IndoorEnvironmentalQuality
 ```
 
 <Tip title="Topic Detection Using LeMUR">
-Check out this cookbook [Custom Topic Tags](https://github.com/AssemblyAI/cookbook/blob/master/lemur/custom-topic-tags.ipynb) for an example of how to leverage LeMUR for custom topic detection.
+Check out this cookbook [Custom Topic Tags](/docs/guides/custom-topic-tags) for an example of how to leverage LeMUR for custom topic detection.
 </Tip>
 
 

--- a/fern/pages/05-guides/sdks/template.mdx
+++ b/fern/pages/05-guides/sdks/template.mdx
@@ -884,7 +884,7 @@ transcript = client.transcripts.transcribe(
 </Tabs>
 
 <Tip title="Fallback to a default language">
-For a workflow that resubmits a transcription request using a default language if the threshold is not reached, see [this cookbook](https://github.com/AssemblyAI/cookbook/blob/master/core-transcription/automatic-language-detection-route-default-language-python.ipynb).
+For a workflow that resubmits a transcription request using a default language if the threshold is not reached, see [this cookbook](/docs/guides/automatic-language-detection-route-default-language).
 </Tip>
 
 

--- a/fern/pages/06-integrations/activepieces.mdx
+++ b/fern/pages/06-integrations/activepieces.mdx
@@ -57,7 +57,7 @@ The AssemblyAI piece for Activepieces provides the following actions:
 #### Upload File
 
 Upload an audio file to AssemblyAI so you can transcribe it.
-You can pass the `Upload URL` output field to the `Audio URL` input field of [Transcribe an Audio File](#transcribe-an-audio-file) module.
+You can pass the `Upload URL` output field to the `Audio URL` input field of Transcribe an Audio File module.
 
 ### Transcripts
 
@@ -66,7 +66,7 @@ You can pass the `Upload URL` output field to the `Audio URL` input field of [Tr
 Transcribe an audio file and wait until the transcript has completed or failed.
 Configure the `Audio URL` field with the URL of the audio file you want to transcribe.
 The `Audio URL` must be accessible by AssemblyAI's servers.
-If you don't have a publicly accessible URL, you can use the [Upload a File](#upload-a-file) module to upload the audio file to AssemblyAI.
+If you don't have a publicly accessible URL, you can use the Upload a File module to upload the audio file to AssemblyAI.
 
 If you don't want to wait until the transcript is ready, uncheck the `Wait until transcript is ready` parameter.
 

--- a/fern/pages/06-integrations/activepieces.mdx
+++ b/fern/pages/06-integrations/activepieces.mdx
@@ -35,7 +35,7 @@ Create a new connection or select an existing one.
 
 ![Select a connection to AssemblyAI in Activepieces](../../assets/img/integrations/activepieces/select-api-key.png)
 
-In the **API Key** field, enter the API key from your [AssemblyAI dashboard](https://www.assemblyai.com/dashboard/login), and click **Save**.
+In the **API Key** field, enter the API key from your [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys), and click **Save**.
 
 ![Configure your connection to AssemblyAI in Activepieces](../../assets/img/integrations/activepieces/configure-api-key.png)
 

--- a/fern/pages/06-integrations/langchain/js.mdx
+++ b/fern/pages/06-integrations/langchain/js.mdx
@@ -56,7 +56,7 @@ bun add langchain @langchain/community
   </Tab>
 </Tabs>
 
-To use the loaders, you need an [AssemblyAI account](https://www.assemblyai.com/dashboard/signup) and get your AssemblyAI API key from the [dashboard](https://www.assemblyai.com/app/account).
+To use the loaders, you need an [AssemblyAI account](https://www.assemblyai.com/dashboard/signup) and get your AssemblyAI API key from the [dashboard](https://www.assemblyai.com/app/api-keys).
 Configure the API key as the `ASSEMBLYAI_API_KEY` environment variable or the `apiKey` options parameter.
 
 ```typescript

--- a/fern/pages/06-integrations/langchain/js.mdx
+++ b/fern/pages/06-integrations/langchain/js.mdx
@@ -88,7 +88,7 @@ console.dir(docs, { depth: Infinity });
 - If the `audio_file` is a local file path, the loader will upload it to AssemblyAI for you.
 - The `audio_file` can also be a video file. See the [list of supported file types in the FAQ doc](https://support.assemblyai.com/articles/2616970375-what-audio-and-video-file-types-are-supported-by-your-api).
 - If you don't pass in the `apiKey` option, the loader will use the `ASSEMBLYAI_API_KEY` environment variable.
-- You can add more properties in addition to `audio`. Find the full list of request parameters in the [AssemblyAI API docs](https://www.assemblyai.com/docs/api-reference/transcript#create-a-transcript).
+- You can add more properties in addition to `audio`. Find the full list of request parameters in the [AssemblyAI API docs](https://www.assemblyai.com/docs/api-reference/overview).
 </Info>
 
 <br />

--- a/fern/pages/06-integrations/langchain/python.mdx
+++ b/fern/pages/06-integrations/langchain/python.mdx
@@ -26,7 +26,7 @@ pip install langchain
 pip install assemblyai
 ```
 
-Set your AssemblyAI API key as an environment variable named `ASSEMBLYAI_API_KEY`. You can [get a free AssemblyAI API key from the AssemblyAI dashboard](https://www.assemblyai.com/dashboard/signup).
+Set your AssemblyAI API key as an environment variable named `ASSEMBLYAI_API_KEY`. You can [get a free AssemblyAI API key from the AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys).
 
 ```bash
 # Mac/Linux:

--- a/fern/pages/06-integrations/llamaindex/python.mdx
+++ b/fern/pages/06-integrations/llamaindex/python.mdx
@@ -24,7 +24,7 @@ First, install the `assemblyai` python package.
 pip install assemblyai
 ```
 
-Set your AssemblyAI API key as an environment variable named `ASSEMBLYAI_API_KEY`. You can [get a free AssemblyAI API key from the AssemblyAI dashboard](https://www.assemblyai.com/dashboard/signup).
+Set your AssemblyAI API key as an environment variable named `ASSEMBLYAI_API_KEY`. You can [get a free AssemblyAI API key from the AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys).
 
 ```bash
 # Mac/Linux:

--- a/fern/pages/06-integrations/llamaindex/ts.mdx
+++ b/fern/pages/06-integrations/llamaindex/ts.mdx
@@ -24,7 +24,7 @@ Looking for the Python integration? Check out the [LlamaIndex Python integration
 
 [Install LlamaIndex.TS by following their instructions](https://ts.llamaindex.ai/installation).
 
-To use the loaders, you need an [AssemblyAI account](https://www.assemblyai.com/dashboard/signup) and get your AssemblyAI API key from the [dashboard](https://www.assemblyai.com/app/account).
+To use the loaders, you need an [AssemblyAI account](https://www.assemblyai.com/dashboard/signup) and get your AssemblyAI API key from the [dashboard](https://www.assemblyai.com/app/api-keys).
 Configure the API key as the `ASSEMBLYAI_API_KEY` environment variable or the `apiKey` options parameter.
 
 ```typescript

--- a/fern/pages/06-integrations/llamaindex/ts.mdx
+++ b/fern/pages/06-integrations/llamaindex/ts.mdx
@@ -56,7 +56,7 @@ console.dir(docs, { depth: Infinity });
 - The `audio` parameter can be a URL, a local file path, a file buffer, or a stream.
 - The `audio` can also be a video file. See the [list of supported file types in the FAQ doc](https://support.assemblyai.com/articles/2616970375-what-audio-and-video-file-types-are-supported-by-your-api).
 - If you don't pass in the `apiKey` option, the loader will use the `ASSEMBLYAI_API_KEY` environment variable.
-- You can add more properties in addition to `audio`. Find the full list of request parameters in the [AssemblyAI API docs](https://www.assemblyai.com/docs/api-reference/transcript#create-a-transcript).
+- You can add more properties in addition to `audio`. Find the full list of request parameters in the [AssemblyAI API docs](https://www.assemblyai.com/docs/api-reference/overview).
 </Info>
 
 <br />

--- a/fern/pages/06-integrations/make.mdx
+++ b/fern/pages/06-integrations/make.mdx
@@ -43,7 +43,7 @@ Select the module that you want to use.
 <Step>
 
 Create a new connection or select an existing one.
-In **AssemblyAI API Key**, enter the API key from your [AssemblyAI dashboard](https://www.assemblyai.com/dashboard/login), and click **Save**.
+In **AssemblyAI API Key**, enter the API key from your [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys), and click **Save**.
 
 ![Create a connection to AssemblyAI in Make](../../assets/img/integrations/make/create-connection.png)
 

--- a/fern/pages/06-integrations/postman.mdx
+++ b/fern/pages/06-integrations/postman.mdx
@@ -30,7 +30,7 @@ Fill out the form and click **Fork Collection**.
 <Step>
 
 Next, click on the **Variables** tab and configure the `apiKey` variable with your AssemblyAI API key.
-You can find your AssemblyAI API key in the [AssemblyAI dashboard](https://www.assemblyai.com/dashboard/login).
+You can find your AssemblyAI API key in the [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys).
 
 ![Configure AssemblyAI API key in Postman collection](../../assets/img/integrations/postman/2-configure-variables.png)
 

--- a/fern/pages/06-integrations/power-automate.mdx
+++ b/fern/pages/06-integrations/power-automate.mdx
@@ -34,7 +34,7 @@ Add a new action, search for AssemblyAI, and select the action that you want to 
 </Step>
 <Step>
 
-You will be prompted to create a connection to AssemblyAI. Give your connection a name and enter the API key from your [AssemblyAI dashboard](https://www.assemblyai.com/dashboard/login), and click **Create new**.
+You will be prompted to create a connection to AssemblyAI. Give your connection a name and enter the API key from your [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys), and click **Create new**.
 
 ![Create a connection to AssemblyAI in Power Automate](../../assets/img/integrations/power-automate/create-connection.png)
 

--- a/fern/pages/08-concepts/account_management.mdx
+++ b/fern/pages/08-concepts/account_management.mdx
@@ -62,7 +62,7 @@ To ensure a smooth experience for all users, certain operations have per-account
 - **Rate limits** for synchronous operations
 
 <Note title="Increasing your usage limits">
-The usage limits displayed on this page are default values based on your account type. If you already have a paid account and want to further increase your usage limits, <a href="https://www.assemblyai.com/contact" target="_blank">contact our Sales team</a> or send an email to our [Support team](support@assemblyai.com).
+The usage limits displayed on this page are default values based on your account type. If you already have a paid account and want to further increase your usage limits, <a href="https://www.assemblyai.com/contact" target="_blank">contact our Sales team</a> or send an email to our [Support team](https://www.assemblyai.com/contact/support).
 </Note>
 
 ### Speech-to-Text usage limits
@@ -95,7 +95,7 @@ AssemblyAI limits the number of concurrent sessions.
 If you're consistently exceeding the limit of concurrent sessions, first make sure that you're terminating sessions properly.
 
 - If you're using the [WebSocket API](https://www.assemblyai.com/docs/api-reference/streaming/realtime) directly, you need to send a `terminate_session` message.
-- If you're using one of our SDKs, see "Transcribe streaming audio from a microphone" for [Python](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/python#step-6-close-the-connection), [TypeScript](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/typescript#step-6-disconnect-the-real-time-service), [Go](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/go#step-5-disconnect-the-transcriber), [C#](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/c#step-6-disconnect-the-real-time-service), or [Java](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/java).
+- If you're using one of our SDKs, see "Transcribe streaming audio from a microphone" for [Python](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/python#step-6-close-the-connection), [C#](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/csharp#step-5-disconnect-the-streaming-service), or [Ruby](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/ruby#step-5-disconnect-the-streaming-service).
 </Note>
 
 ### LeMUR usage limits

--- a/fern/pages/overview.mdx
+++ b/fern/pages/overview.mdx
@@ -31,7 +31,7 @@ To get started using the SDKs, see the following resources:
 
 ## Authorization
 
-To make authorized calls the REST API, your app must provide an authorization header with an API key. You can find your API key in the [AssemblyAI dashboard](https://www.assemblyai.com/app).
+To make authorized calls the REST API, your app must provide an authorization header with an API key. You can find your API key in the [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys).
 
 ```bash title="Authenticated request"
 curl https://api.assemblyai.com/v2/transcript \


### PR DESCRIPTION
Making a PR to update some of the links in our docs. Mostly, it's some broken anchor links and using the new API keys page instead of the account page.