### PR TITLE
remove llama integration due to depreciation and some broken links

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -461,16 +461,6 @@ navigation:
                   - page: JavaScript
                     path: pages/06-integrations/langchain/js.mdx
                     slug: /js
-              - section: LlamaIndex
-                path: pages/06-integrations/llamaindex.mdx
-                slug: /llamaindex
-                contents:
-                  - page: Python
-                    path: pages/06-integrations/llamaindex/python.mdx
-                    slug: /python
-                  - page: TypeScript
-                    path: pages/06-integrations/llamaindex/ts.mdx
-                    slug: /ts
               - page: Semantic Kernel
                 path: pages/06-integrations/semantic-kernel.mdx
               - page: Activepieces

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-language-detection.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/automatic-language-detection.mdx
@@ -1121,5 +1121,5 @@ while (true) {
 <Tip title="Fallback to a default language">
   For a workflow that resubmits a transcription request using a default language
   if the threshold is not reached, see [this
-  cookbook](https://github.com/AssemblyAI/cookbook/blob/master/core-transcription/automatic-language-detection-route-default-language-python.ipynb).
+  cookbook](/docs/guides/automatic-language-detection-route-default-language).
 </Tip>

--- a/fern/pages/02-speech-to-text/speech-recognition.mdx
+++ b/fern/pages/02-speech-to-text/speech-recognition.mdx
@@ -884,7 +884,7 @@ transcript = client.transcripts.transcribe(
 <Tip title="Fallback to a default language">
   For a workflow that resubmits a transcription request using a default language
   if the threshold is not reached, see [this
-  cookbook](https://github.com/AssemblyAI/cookbook/blob/master/core-transcription/automatic-language-detection-route-default-language-python.ipynb).
+  cookbook](/docs/guides/automatic-language-detection-route-default-language).
 </Tip>
 
 ## Set language manually

--- a/fern/pages/06-integrations/index.mdx
+++ b/fern/pages/06-integrations/index.mdx
@@ -41,9 +41,6 @@ AssemblyAI seamlessly integrates with a variety of tools and platforms to enhanc
     Integrate AssemblyAI with LangChain for advanced language model
     applications.
   </Card>
-  <Card title="LlamaIndex" icon="database" href="/docs/integrations/llamaindex">
-    Build powerful search and retrieval systems with LlamaIndex integration.
-  </Card>
   <Card
     title="Semantic Kernel"
     icon="microchip"

--- a/fern/pages/06-integrations/langchain/js.mdx
+++ b/fern/pages/06-integrations/langchain/js.mdx
@@ -116,7 +116,6 @@ console.dir(docs, { depth: Infinity });
 You can learn more about using LangChain with AssemblyAI in these resources:
 
 - [The LangChain docs for the AssemblyAI document loader](https://js.langchain.com/docs/integrations/document_loaders/web_loaders/assemblyai_audio_transcription)
-- [The API reference for the AssemblyAI document loaders](https://js.langchain.com/docs/api/document_loaders_web_assemblyai/)
 - [How to integrate spoken audio into LangChain.js using AssemblyAI](https://www.assemblyai.com/blog/integrate-audio-langchainjs/)
 - [Integrate Audio into LangChain.js apps in 5 Minutes](https://www.youtube.com/watch?v=hNpUSaYZIzs)
 - [AssemblyAI JavaScript SDK](https://github.com/AssemblyAI/assemblyai-node-sdk)

--- a/fern/pages/06-integrations/power-automate.mdx
+++ b/fern/pages/06-integrations/power-automate.mdx
@@ -293,5 +293,4 @@ Delete the data for a previously submitted LeMUR request. The LLM response data,
 
 You can learn more about using Power Automate with AssemblyAI in these resources:
 
-- [Redact PII in Audio with Power Automate and AssemblyAI](https://www.assemblyai.com/blog/redact-pii-audio-with-power-automate/)
 - [Power Automate & Logic Apps docs by Microsoft](https://learn.microsoft.com/en-us/connectors/assemblyai/)

--- a/fern/pages/06-integrations/rivet.mdx
+++ b/fern/pages/06-integrations/rivet.mdx
@@ -35,7 +35,7 @@ Now you can add AssemblyAI nodes to your canvas by right-clicking on the canvas,
 
 ### Transcribe Audio node
 
-The Transcribe Audio node transcribes audio using the [AssemblyAI](https://www.assemblyai.com/) API. It will return a transcript of the given audio source.
+The Transcribe Audio node transcribes audio using the [AssemblyAI API](https://www.assemblyai.com/docs/api-reference/overview) . It will return a transcript of the given audio source.
 
 ![Transcribe Audio node](../../assets/img/integrations/rivet/transcribe-audio-node.png)
 


### PR DESCRIPTION
llama integration was depreciated, so all the links were broken. I felt it would be best to remove that section from our docs.