### PR TITLE
remove aws marketplace link

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -486,8 +486,6 @@ navigation:
                 path: pages/06-integrations/haystack.mdx
               - page: Twilio
                 path: pages/06-integrations/twilio.mdx
-              - link: AWS
-                href: https://aws.amazon.com/marketplace/pp/prodview-j45hta6jdej7c
               - link: Cloudflare
                 href: https://www.assemblyai.com/blog/transcribe-audio-cloudflare-workers-assemblyai-nodejs-typescript/
               - link: Recall


### PR DESCRIPTION
Removed AWS marketplace URL from integrations per [this comment](https://assemblyai.slack.com/archives/C058SSDGFDK/p1743697693782579?thread_ts=1743696868.577049&cid=C058SSDGFDK) from Amy D.