### PR TITLE
clarify that the to key can only contain a single word

### DIFF
--- a/fern/pages/02-speech-to-text/pre-recorded-audio/custom-spelling.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/custom-spelling.mdx
@@ -10,7 +10,7 @@ Custom Spelling lets you customize how words are spelled or formatted in the tra
 
 <Tabs>
   <Tab language="python-sdk" title="Python SDK" default>
-To use Custom Spelling, pass a dictionary to `set_custom_spelling()` on the transcription config. Each key-value pair specifies a mapping from a word or phrase to a new spelling or format. The key specifies the new spelling or format, and the corresponding value is the word or phrase you want to replace.
+To use Custom Spelling, pass a dictionary to `set_custom_spelling()` on the transcription config. Each key-value pair specifies a mapping from a word or phrase to a new spelling or format of a word. The key specifies the new spelling or format, and the corresponding value is the word or phrase you want to replace.
 
 ```python highlight={9-14} maxLines=15
 import assemblyai as aai
@@ -38,7 +38,7 @@ print(transcript.text)
 
   </Tab>
   <Tab language="python" title="Python">
-To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be a list of dictionaries, with each dictionary specifying a mapping from a word or phrase to a new spelling or format.
+To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be a list of dictionaries, with each dictionary specifying a mapping from a word or phrase to a new spelling or format of a word.
 
 ```python highlight={19-28} maxLines=15
 import requests
@@ -94,7 +94,7 @@ while True:
 
   </Tab>
   <Tab language="typescript-sdk" title="TypeScript SDK" default>
-To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of objects, with each object specifying a mapping from a word or phrase to a new spelling or format.
+To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of objects, with each object specifying a mapping from a word or phrase to a new spelling or format of a word.
 
 ```ts highlight={13-22} maxLines=15
 import { AssemblyAI } from "assemblyai";
@@ -131,7 +131,7 @@ run();
 
   </Tab>
   <Tab language="typescript" title="TypeScript">
-  To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of objects, with each object specifying a mapping from a word or phrase to a new spelling or format.
+  To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of objects, with each object specifying a mapping from a word or phrase to a new spelling or format of a word.
 ```ts highlight={19-28} maxLines=15
 import axios from 'axios'
 import fs from 'fs-extra'
@@ -189,7 +189,7 @@ await new Promise((resolve) => setTimeout(resolve, 3000))
 
   </Tab>
   <Tab language="csharp" title="C#">
-  To use Custom Spelling, include `custom_spelling` in your transcription request. The parameter should be an array of objects, with each object specifying a mapping from a word or phrase to a new spelling or format.
+  To use Custom Spelling, include `custom_spelling` in your transcription request. The parameter should be an array of objects, with each object specifying a mapping from a word or phrase to a new spelling or format of a word.
 ```csharp highlight={37-46} maxLines=15
 using System;
 using System.IO;
@@ -285,7 +285,7 @@ using (var httpClient = new HttpClient())
 
   </Tab>
   <Tab language="ruby" title="Ruby">
-  To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of hashes, with each hash specifying a mapping from a word or phrase to a new spelling or format.
+  To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of hashes, with each hash specifying a mapping from a word or phrase to a new spelling or format of a word.
 ```ruby highlight={23-32} maxLines=15
 require 'net/http'
 require 'json'
@@ -362,7 +362,7 @@ end
 
   </Tab>
   <Tab language="php" title="PHP">
-  To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of arrays, with each inner array specifying a mapping from a word or phrase to a new spelling or format.
+  To use Custom Spelling, include `custom_spelling` in your transcription parameters. The parameter should be an array of arrays, with each inner array specifying a mapping from a word or phrase to a new spelling or format of a word.
 ```php highlight={30-39} maxLines=15
 <?php
 $ch = curl_init();
@@ -448,6 +448,6 @@ while (true) {
 
 <Note>
 
-The value in the `to` key is case-sensitive, but the value in the `from` key isn't.
+The value in the `to` key is case-sensitive, but the value in the `from` key isn't. Additionally, the to key must only contain one word, while the from key can contain multiple words.
 
 </Note>

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/custom-spelling.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/custom-spelling.mdx
@@ -448,6 +448,6 @@ while (true) {
 
 <Note>
 
-The value in the `to` key is case-sensitive, but the value in the `from` key isn't. Additionally, the to key must only contain one word, while the from key can contain multiple words.
+The value in the `to` key is case-sensitive, but the value in the `from` key isn't. Additionally, the `to` key must only contain one word, while the `from` key can contain multiple words.
 
 </Note>


### PR DESCRIPTION
* Updated the verbiage in each code block to clarify that the `to` key can only be a single word
* Update the verbiage in the alert box to include a callout that the `to` key can only be a single word