### PR TITLE
fix(docs): fix messaging for temp token expires_in parameter

### DIFF
--- a/fern/pages/02-speech-to-text/streaming.mdx
+++ b/fern/pages/02-speech-to-text/streaming.mdx
@@ -243,7 +243,7 @@ You should generate this token on your server and pass it to the client.
   <Tab language="python-sdk" title="Python SDK" default>
 To generate a temporary token, call `aai.RealtimeTranscriber.create_temporary_token()`.
 
-Use the `expires_in` parameter to specify how long the token should be valid for, in seconds.
+Use the `expires_in` parameter to specify the session duration in seconds for which the token will remain valid.
 
 ```python
 token = aai.RealtimeTranscriber.create_temporary_token(
@@ -255,7 +255,7 @@ token = aai.RealtimeTranscriber.create_temporary_token(
   <Tab language="python" title="Python">
 To generate a temporary token, make a POST request to the temporary token endpoint.
 
-Use the `expires_in` parameter to specify how long the token should be valid for, in seconds.
+Use the `expires_in` parameter to specify the session duration in seconds for which the token will remain valid.
 
 ```python
 token = requests.post(
@@ -272,7 +272,7 @@ token = requests.post(
   <Tab language="typescript-sdk" title="TypeScript SDK">
 To generate a temporary token, call `client.realtime.createTemporaryToken()`.
 
-Use the `expires_in` parameter to specify how long the token should be valid for, in seconds.
+Use the `expires_in` parameter to specify the session duration in seconds for which the token will remain valid.
 
 ```ts
 const token = await client.realtime.createTemporaryToken({ expires_in: 60 });
@@ -282,7 +282,7 @@ const token = await client.realtime.createTemporaryToken({ expires_in: 60 });
   <Tab language="typescript" title="TypeScript">
 To generate a temporary token, make a POST request to the temporary token endpoint.
 
-Use the `expires_in` parameter to specify how long the token should be valid for, in seconds.
+Use the `expires_in` parameter to specify the session duration in seconds for which the token will remain valid.
 
 ```ts
 const token = await axios
@@ -303,7 +303,7 @@ const token = await axios
   <Tab language="csharp" title="C#">
 To generate a temporary token, make a POST request to the temporary token endpoint.
 
-Use the `expires_in` parameter to specify how long the token should be valid for, in seconds.
+Use the `expires_in` parameter to specify the session duration in seconds for which the token will remain valid.
 
 ```csharp
 var response = (await client.PostAsJsonAsync("https://api.assemblyai.com/v2/realtime/token",
@@ -316,7 +316,7 @@ var token = JsonConvert.DeserializeObject<dynamic>(response).token;
   <Tab language="ruby" title="Ruby">
 To generate a temporary token, make a POST request to the temporary token endpoint.
 
-Use the `expires_in` parameter to specify how long the token should be valid for, in seconds.
+Use the `expires_in` parameter to specify the session duration in seconds for which the token will remain valid.
 
 ```ruby
 uri = URI('https://api.assemblyai.com/v2/realtime/token')
@@ -334,7 +334,7 @@ token = JSON.parse(response.body)['token']
   <Tab language="curl" title="cURL">
 To generate a temporary token, make a POST request to the temporary token endpoint.
 
-Use the `expires_in` parameter to specify how long the token should be valid for, in seconds.
+Use the `expires_in` parameter to specify the session duration in seconds for which the token will remain valid.
 
 ```
 curl -X POST https://api.assemblyai.com/v2/realtime/token \


### PR DESCRIPTION
Correcting the messaging in the docs to specify the expires_in parameter affects the session duration. More info in thread [here](https://assemblyai.slack.com/archives/C05S6N34ZMY/p1744649100690899).