### PR TITLE
fix(docs): add missing /v2 to upload endpoint URL

### DIFF
--- a/fern/pages/01-getting-started/transcribe-an-audio-file/python.mdx
+++ b/fern/pages/01-getting-started/transcribe-an-audio-file/python.mdx
@@ -64,7 +64,7 @@ Here's the full sample code for what you'll build in this tutorial:
 
     ''' Or upload a local file:
     with open("./example.mp3", "rb") as f:
-        response = requests.post(base_url + "/upload", headers=headers, data=f)
+        response = requests.post(base_url + "/v2/upload", headers=headers, data=f)
 
         if response.status_code != 200:
             print(f"Error: {response.status_code}, Response: {response.text}")


### PR DESCRIPTION
Adding /v2 to the local audio file snippet, as without this it leads to an SSL error.