### PR TITLE
chore(docs): adjust nano model messaging

### DIFF
--- a/fern/pages/01-getting-started/models.mdx
+++ b/fern/pages/01-getting-started/models.mdx
@@ -61,7 +61,6 @@ AssemblyAI offers several state-of-the-art speech recognition models, each optim
 - **Key benefits**:
   - Most cost-effective option
   - Widest language support
-  - Fastest transcription speed
 
 ### Streaming
 


### PR DESCRIPTION
Removed line stating Nano offers the fastest transcription speed, as it is our slowest model.