### PR TITLE
Add `schema` to `uploadFile` endpoint `requestBody`

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -57,7 +57,12 @@
         "x-fern-sdk-method-name": "upload",
         "requestBody": {
           "content": {
-            "application/octet-stream": {}
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
           }
         },
         "responses": {

--- a/openapi.yml
+++ b/openapi.yml
@@ -46,7 +46,10 @@ paths:
       x-fern-sdk-method-name: upload
       requestBody:
         content:
-          application/octet-stream: {}
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
       responses:
         "200":
           x-label: Media file uploaded


### PR DESCRIPTION
We are generating an API client in PHP using `openapi-generator-cli`. We noticed that the `uploadFile` endpoint/method was not usable, because it didn’t accept a file as request body. It turns out that adding a simple `schema` to the endpoint’s `requestBody` resolves this, per the example for [file uploads by Swagger](https://swagger.io/docs/specification/v3_0/describing-request-body/file-upload/).