### PR TITLE
chore(usm-streaming): update known issues

### DIFF
--- a/fern/pages/02-speech-to-text/universal-streaming.mdx
+++ b/fern/pages/02-speech-to-text/universal-streaming.mdx
@@ -546,6 +546,7 @@ This is an early access version of the model. Development is ongoing to reduce l
 
 These are issues currently known to exist in the API and being worked on by our team:
 
+- Brief utterances will not endpoint and remain as partial transcripts
 - Partial transcripts may start with sub-words
 - Subsequent partials may contain the same text content
 - Transcript confidence scores may currently be unstable


### PR DESCRIPTION
Currently utterances <240ms are not being end-pointed, leading them to become stuck as partial transcripts.
Expected to be fixed in the next model update.