### PR TITLE
fix: clarify that Slam is only available on the US endpoint currently

### DIFF
--- a/fern/pages/01-getting-started/slam-1.mdx
+++ b/fern/pages/01-getting-started/slam-1.mdx
@@ -9,7 +9,7 @@ description: "Learn how to transcribe prerecorded audio using Slam-1."
 
 Slam-1 is our new Speech Language Model that combines LLM architecture with ASR encoders for superior speech-to-text transcription. This model delivers unprecedented accuracy through its understanding of context and semantic meaning. Check out our [Slam-1 blog post](https://www.assemblyai.com/blog/slam-1-public-beta) to learn more about this new model!
 
-<Info>Slam-1 is currently only supported for English.</Info>
+<Info>Slam-1 is currently only supported for English and the US endpoint.</Info>
 
 ## Quick Start
 


### PR DESCRIPTION
Adds brief clarification that Slam is only currently available on the EU endpoint. Requesting Slam on EU results in an error (telling the user to use the params `universal`, `best`, or `nano`) which is a bit confusing as I don't believe we make note of this in our docs/announcement. 