### PR TITLE
Comment out C#/Ruby guides 

### DIFF
--- a/fern/pages/02-speech-to-text/streaming.mdx
+++ b/fern/pages/02-speech-to-text/streaming.mdx
@@ -18,8 +18,8 @@ Check out our getting started guides:
 
 - [Python](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/python)
 - [JavaScript / TypeScript](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/typescript)
-- [C#](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/csharp)
-- [Ruby](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/ruby)
+{/* - [C#](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/csharp) */}
+{/* - [Ruby](/docs/getting-started/transcribe-streaming-audio-from-a-microphone/ruby)  */}
 
 </Info>
 


### PR DESCRIPTION
The Ruby and C# Getting Started links are currently broken. They're commented out in the docs.yml file, but are still referenced in the Streaming section/lead to 404s when clicked.