### PR TITLE
Fix JS SDK for Universal-Streaming

### DIFF
--- a/fern/pages/01-getting-started/transcribe-streaming-audio.mdx
+++ b/fern/pages/01-getting-started/transcribe-streaming-audio.mdx
@@ -366,7 +366,7 @@ const run = async () => {
 
   const transcriber = client.streaming.transcriber({
     sampleRate: 16_000,
-    format_turns: true
+    formatTurns: true
   });
 
   transcriber.on("open", ({ id }) => {
@@ -964,7 +964,7 @@ Create a new streaming service from the AssemblyAI client and add it to your asy
 ```typescript
 const transcriber = client.streaming.transcriber({
   sampleRate: 16_000,
-  format_turns: true
+  formatTurns: true
 });
 ```
 

--- a/fern/pages/02-speech-to-text/universal-streaming/universal-streaming.mdx
+++ b/fern/pages/02-speech-to-text/universal-streaming/universal-streaming.mdx
@@ -70,7 +70,7 @@ To run the quickstart:
     Create a new JavaScript file (for example, `main.js`) and paste the code provided below inside.
     </Step>
     <Step>
-    Insert your API key to line 7 and 12.
+    Insert your API key to line 7.
     </Step>
     <Step>
     Install the necessary libraries
@@ -503,7 +503,7 @@ const run = async () => {
 
   const transcriber = client.streaming.transcriber({
     sampleRate: 16_000,
-    apiKey: "<YOUR_API_KEY>",
+    formatTurns: true
   });
 
   transcriber.on("open", ({ id }) => {


### PR DESCRIPTION
- Proper param is `formatTurns` for JS/TS.
- SDK's `transcriber` apiKey is optional if the `client` is already authed.
