### PR TITLE
fix streaming concurrency scaling interval

### DIFF
--- a/fern/pages/08-concepts/account_management.mdx
+++ b/fern/pages/08-concepts/account_management.mdx
@@ -105,7 +105,7 @@ AssemblyAI limits the number of concurrent streaming sessions.
 <Tip>
 Our Streaming STT feature includes automatically scaling concurrency limits for paid accounts.
 
-Anytime you are using 70% or more of your current limit, your concurrency limit will automatically increase and scale up by 10% every 10 seconds.
+Anytime you are using 70% or more of your current limit, your concurrency limit will automatically increase and scale up by 10% every 60 seconds.
 
 As your traffic starts to scale back down and you are using less than 50% of your current limit, your concurrency will start to scale back down until it eventually returns to your default value.
 </Tip>


### PR DESCRIPTION
Correct streaming concurrency frequency from every 10 seconds to every 60 seconds.