### PR TITLE
fix(misc): Streaming fixes

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -51,8 +51,7 @@ navigation:
             path: pages/01-getting-started/transcribe-an-audio-file2.mdx
           - page: Transcribe streaming audio
             slug: /getting-started/transcribe-streaming-audio
-            path:
-              pages/01-getting-started/transcribe-streaming-audio.mdx
+            path: pages/01-getting-started/transcribe-streaming-audio.mdx
           - section: Build a voice agent
             icon: sparkles
             skip-slug: true
@@ -399,6 +398,10 @@ navigation:
               - page: Migrating from Streaming v2 to Streaming v3
                 path: pages\05-guides\cookbooks\streaming-stt\v2_to_v3.mdx
                 slug: v2_to_v3_migration
+                hidden: true
+              - page: Transcribe Audio Files with Streaming Speech-to-Text
+                path: pages/05-guides/cookbooks/streaming-stt/transcribe_audio_file.mdx
+                slug: streaming_transcribe_audio_file
                 hidden: true
           - section: SDK References
             hidden: true
@@ -864,5 +867,3 @@ redirects:
     destination: /docs/speech-to-text/universal-streaming/pipecat
   - source: /docs/getting-started/transcribe-streaming-audio-from-a-microphone
     destination: /docs/getting-started/transcribe-streaming-audio
-
- 

--- a/fern/pages/02-speech-to-text/universal-streaming/turn-detection.mdx
+++ b/fern/pages/02-speech-to-text/universal-streaming/turn-detection.mdx
@@ -10,9 +10,10 @@ AssemblyAI's end-of-turn detection functionality is integrated into our Streamin
 This functionality is built natively into the STT model, making it ideal for addressing two common problems voice agent developers face: awkward pauses (long silence) or the risk of making premature interruptions (short silence), both of which disrupt the natural flow of conversation.
 
 This approach allows for:
-* Semantic understanding of natural speech patterns rather than simple silence thresholds
-* Support for natural pauses and thinking time without premature responses
-* Smooth conversation flow without awkward interruptions or artificial delays
+
+- Semantic understanding of natural speech patterns rather than simple silence thresholds
+- Support for natural pauses and thinking time without premature responses
+- Smooth conversation flow without awkward interruptions or artificial delays
 
 <Note>
   End-of-turn and end-of-utterances refer to the same thing and may be used
@@ -26,12 +27,12 @@ Triggers when **all** conditions are met:
 #### EOT token predicted
 
 - Model predicts semantic end-of-turn with a probability greater than `end_of_turn_confidence_threshold`
-- Default: 0.5 (user configurable)
+- Default: 0.7 (user configurable)
 
 #### Minimum silence duration has passed
 
 - After the last non-silence word token, `min_end_of_turn_silence_when_confident` milliseconds must pass
-- Default: 400ms (user configurable)
+- Default: 160ms (user configurable)
 
 #### Minimum speech duration spoken
 
@@ -59,7 +60,7 @@ Triggers when **all** conditions are met:
 
 ### Disable turn detection
 
-To disable model-based turn detection, set `end_of_turn_confidence_threshold` to 1. This will stop the model from predicting end-of-turns and will only use silence-based detection. 
+To disable model-based turn detection, set `end_of_turn_confidence_threshold` to 1. This will stop the model from predicting end-of-turns and will only use silence-based detection.
 If you are using your own form of turn detection (such as VAD or a custom turn detection model), you can send a `ForceEndpoint` event to the server to force the end of a turn and receive the final turn transcript.
 
 ```python
@@ -71,6 +72,3 @@ ws.send(json.dumps({"type": "ForceEndpoint"}))
 - Silence-based detection can override model-based detection even with high EOT confidence thresholds
 - Word finalization always takes precedence — endpointing won't occur until the last word is finalized
 - We define end-of-turn detection as the process of detecting the end of sustained speech activity, often called end-pointing in the Voice Agents context
-
-
-

--- a/fern/pages/02-speech-to-text/universal-streaming/universal-streaming.mdx
+++ b/fern/pages/02-speech-to-text/universal-streaming/universal-streaming.mdx
@@ -1093,12 +1093,13 @@ ws = new WebSocket(`${API_ENDPOINT_BASE_URL}?${querystring.stringify(paramsWithT
   type="int"
   default={160}
 >
-  The minimum amount of silence required to detect end of turn when confident.
+  The minimum amount of silence in milliseconds required to detect end of turn
+  when confident.
 </ParamField>
 
 <ParamField path="max_turn_silence" type="int" default={2400}>
-  The maximum amount of silence allowed in a turn before end of turn is
-  triggered.
+  The maximum amount of silence in milliseconds allowed in a turn before end of
+  turn is triggered.
 </ParamField>
 
 ### Audio requirements

--- a/fern/pages/05-guides/cookbooks/streaming-stt/transcribe_audio_file.mdx
+++ b/fern/pages/05-guides/cookbooks/streaming-stt/transcribe_audio_file.mdx
@@ -1,0 +1,216 @@
+---
+title: "Transcribe audio files with Streaming"
+---
+
+This guide shows you how to transcribe audio files using our Streaming API. The Streaming API is capable of transcribing WAV audio files. It can also handle audio files with different sample rates.
+
+## Quickstart
+
+```python
+import assemblyai as aai
+from assemblyai.streaming.v3 import (
+    BeginEvent,
+    StreamingClient,
+    StreamingClientOptions,
+    StreamingError,
+    StreamingEvents,
+    StreamingParameters,
+    TerminationEvent,
+    TurnEvent
+)
+from typing import Type
+
+def on_begin(self: Type[StreamingClient], event: BeginEvent):
+  "This function is called when the connection has been established."
+
+  print("Session ID:", event.id)
+
+def on_turn(self: Type[StreamingClient], event: TurnEvent):
+  "This function is called when a new transcript has been received."
+
+  print(event.transcript, end="\r\n")
+
+def on_terminated(self: Type[StreamingClient], event: TerminationEvent):
+  "This function is called when an error occurs."
+
+  print(
+    f"Session terminated: {event.audio_duration_seconds} seconds of audio processed"
+  )
+
+def on_error(self: Type[StreamingClient], error: StreamingError):
+  "This function is called when the connection has been closed."
+
+  print(f"Error occurred: {error}")
+
+
+# Create the streaming client
+client = StreamingClient(
+  StreamingClientOptions(
+    api_key="YOUR_API_KEY"
+  )
+)
+
+client.on(StreamingEvents.Begin, on_begin)
+client.on(StreamingEvents.Turn, on_turn)
+client.on(StreamingEvents.Termination, on_terminated)
+client.on(StreamingEvents.Error, on_error)
+
+def stream_file(filepath: str, sample_rate: int):
+    """Stream audio file in 50ms chunks instead of 300ms"""
+    import time
+    import wave
+
+    chunk_duration = 0.1
+
+    with wave.open(filepath, 'rb') as wav_file:
+        if wav_file.getnchannels() != 1:
+            raise ValueError("Only mono audio is supported")
+
+        file_sample_rate = wav_file.getframerate()
+        if file_sample_rate != sample_rate:
+            print(f"Warning: File sample rate ({file_sample_rate}) doesn't match expected rate ({sample_rate})")
+
+        frames_per_chunk = int(file_sample_rate * chunk_duration)
+
+        while True:
+            frames = wav_file.readframes(frames_per_chunk)
+
+            if not frames:
+                break
+
+            yield frames
+
+            time.sleep(chunk_duration)
+
+file_stream = stream_file(
+  filepath="audio.wav",
+  sample_rate=44100,
+)
+
+client.stream(file_stream)
+
+client.disconnect()
+```
+
+## Step-by-step guide
+
+Before we begin, make sure you have an AssemblyAI account and an API key. You can [sign up](https://assemblyai.com/dashboard/signup) and get your API key from your dashboard.
+
+### Install/import packages & set API key
+
+Install the package assemblyai.
+
+```bash
+pip install assemblyai
+```
+
+Import packages.
+
+```python
+import assemblyai as aai
+from assemblyai.streaming.v3 import (
+    BeginEvent,
+    StreamingClient,
+    StreamingClientOptions,
+    StreamingError,
+    StreamingEvents,
+    StreamingParameters,
+    TerminationEvent,
+    TurnEvent
+)
+from typing import Type
+```
+
+### Websocket Event Handlers
+
+```python
+def on_begin(self: Type[StreamingClient], event: BeginEvent):
+  "This function is called when the connection has been established."
+
+  print("Session ID:", event.id)
+
+def on_turn(self: Type[StreamingClient], event: TurnEvent):
+  "This function is called when a new transcript has been received."
+
+  print(event.transcript, end="\r\n")
+
+def on_terminated(self: Type[StreamingClient], event: TerminationEvent):
+  "This function is called when an error occurs."
+
+  print(
+    f"Session terminated: {event.audio_duration_seconds} seconds of audio processed"
+  )
+
+def on_error(self: Type[StreamingClient], error: StreamingError):
+  "This function is called when the connection has been closed."
+
+  print(f"Error occurred: {error}")
+```
+
+### Create the streaming client
+
+```python
+# Create the streaming client
+client = StreamingClient(
+  StreamingClientOptions(
+    api_key="YOUR_API_KEY"
+  )
+)
+
+client.on(StreamingEvents.Begin, on_begin)
+client.on(StreamingEvents.Turn, on_turn)
+client.on(StreamingEvents.Termination, on_terminated)
+client.on(StreamingEvents.Error, on_error)
+```
+
+### Helper functions for streaming files
+
+Create a helper function to stream your file.
+
+```python
+def stream_file(filepath: str, sample_rate: int):
+    """Stream audio file in 50ms chunks instead of 300ms"""
+    import time
+    import wave
+
+    chunk_duration = 0.1
+
+    with wave.open(filepath, 'rb') as wav_file:
+        if wav_file.getnchannels() != 1:
+            raise ValueError("Only mono audio is supported")
+
+        file_sample_rate = wav_file.getframerate()
+        if file_sample_rate != sample_rate:
+            print(f"Warning: File sample rate ({file_sample_rate}) doesn't match expected rate ({sample_rate})")
+
+        frames_per_chunk = int(file_sample_rate * chunk_duration)
+
+        while True:
+            frames = wav_file.readframes(frames_per_chunk)
+
+            if not frames:
+                break
+
+            yield frames
+
+            time.sleep(chunk_duration)
+
+file_stream = stream_file(
+  filepath="audio.wav",
+  sample_rate=44100,
+)
+```
+
+### Stream the file
+
+```python
+client.stream(file_stream)
+```
+
+### Disconnect the client
+
+```python
+client.disconnect()
+```
+
+You can press Ctrl+C to stop the transcription.

--- a/fern/pages/05-guides/index.mdx
+++ b/fern/pages/05-guides/index.mdx
@@ -1104,6 +1104,18 @@ For examples using the API without SDKs see [API guides](#api-guides).
         />
       </a>
     </li>
+    <li>
+      <a
+        href="guides/streaming_transcribe_audio_file"
+        className="link-cta rounded-lg flex items-center gap-2"
+      >
+        Transcribe Audio Files with Streaming Speech-to-Text{" "}
+        <Icon
+          icon="duotone arrow-right"
+          color="rgba(var(--accent-aaa),var(--tw-text-opacity,1))"
+        />
+      </a>
+    </li>
   </ul>
 </div>
 

--- a/fern/pages/05-guides/streaming.mdx
+++ b/fern/pages/05-guides/streaming.mdx
@@ -166,18 +166,6 @@ AssemblyAI's Streaming Speech-to-Text (STT) allows you to transcribe live audio 
   <ul className="no-bullets">
     <li>
       <a
-        href="https://github.com/AssemblyAI/twilio-realtime-tutorial"
-        className="link-cta rounded-lg flex items-center gap-2"
-      >
-        Use Twilio with Node SDK{" "}
-        <Icon
-          icon="duotone arrow-right"
-          color="rgba(var(--accent-aaa),var(--tw-text-opacity,1))"
-        />
-      </a>
-    </li>
-    <li>
-      <a
         href="noise_reduction_streaming"
         className="link-cta rounded-lg flex items-center gap-2"
       >

--- a/fern/pages/05-guides/streaming.mdx
+++ b/fern/pages/05-guides/streaming.mdx
@@ -188,5 +188,17 @@ AssemblyAI's Streaming Speech-to-Text (STT) allows you to transcribe live audio 
         />
       </a>
     </li>
+    <li>
+      <a
+        href="streaming_transcribe_audio_file"
+        className="link-cta rounded-lg flex items-center gap-2"
+      >
+        Transcribe Audio Files with Streaming Speech-to-Text{" "}
+        <Icon
+          icon="duotone arrow-right"
+          color="rgba(var(--accent-aaa),var(--tw-text-opacity,1))"
+        />
+      </a>
+    </li>
   </ul>
 </div>

--- a/fern/pages/06-integrations/twilio.mdx
+++ b/fern/pages/06-integrations/twilio.mdx
@@ -20,7 +20,3 @@ Blog posts:
 Videos:
 
 - [Transcribe Twilio Phone Calls in Real-Time with AssemblyAI | JavaScript WebSockets Tutorial](https://youtu.be/3XmtJgWcOT0)
-
-Tutorials:
-
-- [AssemblyAI's JavaScript SDK & Twilio Real-Time Tutorial](https://github.com/AssemblyAI/twilio-realtime-tutorial)

--- a/fern/usm-streaming-overrides.yml
+++ b/fern/usm-streaming-overrides.yml
@@ -8,13 +8,13 @@ channels:
       token:
         x-fern-optional: true
       format_turns:
-        x-fern-type: optional<boolean>
+        x-fern-optional: true
       end_of_turn_confidence_threshold:
-        x-fern-type: optional<float>
+        x-fern-optional: true
       min_end_of_turn_silence_when_confident:
-        x-fern-type: optional<integer>
+        x-fern-optional: true
       max_turn_silence:
-        x-fern-type: optional<integer>
+        x-fern-optional: true
     x-fern-examples:
       - name: Speech-to-Text Example
         summary: This is an example of a speech-to-text session

--- a/usm-streaming.yml
+++ b/usm-streaming.yml
@@ -38,11 +38,8 @@ channels:
       format_turns:
         description: Whether to return formatted final transcripts
         location: $message.payload#/format_turns
-        enum:
-          - "true"
-          - "false"
-        examples:
-          - "true"
+        enum: ["true", "false"]
+        default: "false"
 
       end_of_turn_confidence_threshold:
         description: The confidence threshold (0.0 to 1.0) to use when determining if the end of a turn has been reached
@@ -50,20 +47,23 @@ channels:
         examples:
           - "0.4"
           - "0.7"
+        default: "0.7"
 
       min_end_of_turn_silence_when_confident:
-        description: The minimum amount of silence required to detect end of turn when confident
+        description: The minimum amount of silence in milliseconds required to detect end of turn when confident
         location: $message.payload#/min_end_of_turn_silence_when_confident
         examples:
           - "480"
           - "600"
+        default: "160"
 
       max_turn_silence:
-        description: The maximum amount of silence allowed in a turn before end of turn is triggered
+        description: The maximum amount of silence in milliseconds allowed in a turn before end of turn is triggered
         location: $message.payload#/max_turn_silence
         examples:
           - "700"
           - "1000"
+        default: "2400"
 
       ApiKey:
         description: >-


### PR DESCRIPTION
- new cookbook: Transcribe audio files with Streaming
- removes callout for outdated Twilio/Node streaming guides
- adds default values to the API reference
- makes fixes to Streaming default values
- adds that integers in our Streaming API references refer to milliseconds