### PR TITLE
Add formatting to streaming params for clarity

### DIFF
--- a/fern/pages/02-speech-to-text/universal-streaming/turn-detection.mdx
+++ b/fern/pages/02-speech-to-text/universal-streaming/turn-detection.mdx
@@ -27,17 +27,18 @@ Triggers when **all** conditions are met:
 #### EOT token predicted
 
 - Model predicts semantic end-of-turn with a probability greater than `end_of_turn_confidence_threshold`
-- Default: 0.7 (user configurable)
+- Default: `0.7` (user configurable)
 
 #### Minimum silence duration has passed
 
 - After the last non-silence word token, `min_end_of_turn_silence_when_confident` milliseconds must pass
-- Default: 160ms (user configurable)
+- Default: `160 ms` (user configurable)
+- Format: `milliseconds`
 
 #### Minimum speech duration spoken
 
-- The user must speak for at least 80ms since the last end-of-turn (ensures at least one word)
-- Set to 80 ms (internal)
+- The user must speak for at least `80 ms` since the last end-of-turn (ensures at least one word)
+- Set to `80 ms` (internal)
 
 #### Word finalized
 
@@ -50,13 +51,14 @@ Triggers when **all** conditions are met:
 
 #### Minimum speech duration spoken
 
-- The user must speak for at least 80ms since the last end-of-turn (ensures at least one word)
-- Set to 80 ms (internal)
+- The user must speak for at least `80 ms` since the last end-of-turn (ensures at least one word)
+- Set to `80 ms` (internal)
 
 #### Maximum silence duration has passed
 
 - After the last non-silence word token, `max_turn_silence` milliseconds must pass
-- Default: 2400ms (user configurable)
+- Default: `2400 ms` (user configurable)
+- Format: `milliseconds`
 
 ### Disable turn detection
 

--- a/fern/pages/02-speech-to-text/universal-streaming/universal-streaming.mdx
+++ b/fern/pages/02-speech-to-text/universal-streaming/universal-streaming.mdx
@@ -1093,12 +1093,12 @@ ws = new WebSocket(`${API_ENDPOINT_BASE_URL}?${querystring.stringify(paramsWithT
   type="int"
   default={160}
 >
-  The minimum amount of silence in milliseconds required to detect end of turn
+  The minimum amount of silence in `milliseconds` required to detect end of turn
   when confident.
 </ParamField>
 
 <ParamField path="max_turn_silence" type="int" default={2400}>
-  The maximum amount of silence in milliseconds allowed in a turn before end of
+  The maximum amount of silence in `milliseconds` allowed in a turn before end of
   turn is triggered.
 </ParamField>
 


### PR DESCRIPTION
To build on [this PR](https://github.com/AssemblyAI/assemblyai-api-spec/pull/314/files) — Just some quick ideas to make it as clear as possible our Streaming parameter values are in `ms`. Open to suggestions here.

Context from Dylan — https://assemblyai.slack.com/archives/C05S6N34ZMY/p1749729942175489?thread_ts=1749720319.458209&cid=C05S6N34ZMY