### PR TITLE
fix streaming link and reduce noise cookbook

### DIFF
--- a/fern/pages/05-guides/cookbooks/streaming-stt/noise_reduction_streaming.mdx
+++ b/fern/pages/05-guides/cookbooks/streaming-stt/noise_reduction_streaming.mdx
@@ -38,34 +38,27 @@ logging.basicConfig(level=logging.INFO)
 api_key = "<YOUR_API_KEY>"
 
 # --- Noise-reduced microphone stream ---
-class NoiseReducedMicrophoneStream:
-    def __init__(self, sample_rate):
-        self.sample_rate = sample_rate
-        self.buffer = np.array([])
-        self.buffer_size = int(sample_rate * 0.5)  # 0.5 second buffer
-        self.mic = aai.extras.MicrophoneStream(sample_rate=sample_rate)
+def noise_reduced_mic_stream(sample_rate=16000):
+    mic = aai.extras.MicrophoneStream(sample_rate=sample_rate)
+    buffer = np.array([], dtype=np.int16)
+    buffer_size = int(sample_rate * 0.5)  # 0.5 seconds
 
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        raw_audio = next(self.mic)
+    for raw_audio in mic:
         audio_data = np.frombuffer(raw_audio, dtype=np.int16)
-        self.buffer = np.append(self.buffer, audio_data)
+        buffer = np.append(buffer, audio_data)
 
-        if len(self.buffer) >= self.buffer_size:
-            float_audio = self.buffer.astype(np.float32) / 32768.0
+        if len(buffer) >= buffer_size:
+            float_audio = buffer.astype(np.float32) / 32768.0
             denoised = nr.reduce_noise(
                 y=float_audio,
-                sr=self.sample_rate,
+                sr=sample_rate,
                 prop_decrease=0.75,
                 n_fft=1024,
             )
             int_audio = (denoised * 32768.0).astype(np.int16)
-            self.buffer = self.buffer[-1024:]  # keep some overlap
-            return int_audio.tobytes()
+            buffer = buffer[-1024:]  # keep some overlap
+            yield int_audio.tobytes()
 
-        return b''
 
 # --- Event Handlers ---
 def on_begin(self: Type[StreamingClient], event: BeginEvent):
@@ -105,7 +98,7 @@ def main():
     )
 
     try:
-        denoised_stream = NoiseReducedMicrophoneStream(sample_rate=16000)
+        denoised_stream = noise_reduced_mic_stream(sample_rate=16000)
         client.stream(denoised_stream)
     finally:
         client.disconnect(terminate=True)
@@ -149,6 +142,29 @@ api_key = "<YOUR_API_KEY>"
 
 **Make sure not to share this token with anyone** - it is a private key associated uniquely to your account.
 
+Create a generator function that includes noise reduction.
+
+```python
+def noise_reduced_mic_stream(sample_rate=16000):
+    mic = aai.extras.MicrophoneStream(sample_rate=sample_rate)
+    buffer = np.array([], dtype=np.int16)
+    buffer_size = int(sample_rate * 0.5)  # 0.5 seconds
+    for raw_audio in mic:
+        audio_data = np.frombuffer(raw_audio, dtype=np.int16)
+        buffer = np.append(buffer, audio_data)
+        if len(buffer) >= buffer_size:
+            float_audio = buffer.astype(np.float32) / 32768.0
+            denoised = nr.reduce_noise(
+                y=float_audio,
+                sr=sample_rate,
+                prop_decrease=0.75,
+                n_fft=1024,
+            )
+            int_audio = (denoised * 32768.0).astype(np.int16)
+            buffer = buffer[-1024:]  # keep some overlap
+            yield int_audio.tobytes()
+```
+
 Create functions to handle different events during transcription.
 
 ```python
@@ -168,58 +184,7 @@ def on_error(self: Type[StreamingClient], error: StreamingError):
     print(f" Error occurred: {error}")
 ```
 
-Create a custom stream class that includes noise reduction.
-
-```python
-class NoiseReducedMicrophoneStream:
-    def __init__(self, sample_rate):
-        self.microphone_stream = aai.extras.MicrophoneStream(sample_rate=sample_rate)
-        self.sample_rate = sample_rate
-        self.buffer = np.array([])
-        self.buffer_size = int(sample_rate * 0.5)  # 0.5 seconds buffer
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        # Get audio chunk from microphone
-        audio_chunk = next(self.microphone_stream)
-
-        # Convert bytes to numpy array
-        audio_data = np.frombuffer(audio_chunk, dtype=np.int16)
-
-        # Add to buffer
-        self.buffer = np.append(self.buffer, audio_data)
-
-        # Process when buffer is full
-        if len(self.buffer) >= self.buffer_size:
-            # Convert to float32 for noise reduction
-            float_buffer = self.buffer.astype(np.float32) / 32768.0
-
-            # Apply noise reduction
-            # You can tweak these parameters to change the aggressiveness of the noise reduction
-            reduced_noise = nr.reduce_noise(
-                y=float_buffer,
-                sr=self.sample_rate,
-                prop_decrease=0.75,
-                n_fft=1024
-            )
-
-            # Convert back to int16
-            processed_chunk = (reduced_noise * 32768.0).astype(np.int16)
-
-            # Clear buffer but keep a small overlap
-            overlap = 1024
-            self.buffer = self.buffer[-overlap:] if len(self.buffer) > overlap else np.array([])
-
-            # Convert back to bytes
-            return processed_chunk.tobytes()
-
-        # If buffer not full, return empty bytes
-        return b''
-```
-
-Now we create our transcriber and `NoiseReducedMicrophoneStream`.
+Now we create our transcriber and `noise_reduced_mic_stream`.
 
 ```python
 def main():
@@ -243,7 +208,7 @@ def main():
     )
 
     try:
-        denoised_stream = NoiseReducedMicrophoneStream(sample_rate=16000)
+        denoised_stream = noise_reduced_mic_stream(sample_rate=16000)
         client.stream(denoised_stream)
     finally:
         client.disconnect(terminate=True)

--- a/fern/pages/05-guides/streaming.mdx
+++ b/fern/pages/05-guides/streaming.mdx
@@ -49,7 +49,7 @@ AssemblyAI's Streaming Speech-to-Text (STT) allows you to transcribe live audio 
   <ul className="no-bullets">
     <li>
       <a
-        href="/docs/guides/real-time-streaming-transcription"
+        href="/docs/speech-to-text/universal-streaming"
         className="link-cta rounded-lg flex items-center gap-2"
       >
         Using real-time streaming{" "}


### PR DESCRIPTION
The noise reduction cookbook no longer worked with the universal-streaming update:


<img width="620" alt="Screenshot 2025-06-13 at 4 04 22 PM" src="https://github.com/user-attachments/assets/c6abe014-2136-4ece-9f87-57ebb2ea17dc" />


I also updated the [Using real-time streaming](https://www.assemblyai.com/docs/guides/real-time-streaming-transcription) link to link to Universal streaming instead of legacy.