### PR TITLE
update speaker_options verbiage and hide legacy streaming page

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -669,6 +669,7 @@ navigation:
           - page: Streaming audio (Legacy)
             path: pages/02-speech-to-text/streaming.mdx
             slug: /streaming
+            hidden: true
       - section: Speech Understanding
         skip-slug: true
         contents:

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/speaker-diarization.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/speaker-diarization.mdx
@@ -494,9 +494,9 @@ curl https://api.assemblyai.com/v2/transcript \
 
 ## Set a range of possible speakers
 
-You can set a range of possible speakers in the audio file by setting the `speaker_options` parameter.
+You can set a range of possible speakers in the audio file by setting the `speaker_options` parameter. By default, the model will return between 1 and 10 speakers.
 
-This parameter is suitable for use cases where there is a known minimum/maximum number of speakers in the audio file.
+This parameter is suitable for use cases where there is a known minimum/maximum number of speakers in the audio file that is outside the bounds of the default value of 1 to 10 speakers.
 
 <Warning>
   Setting `max_speakers_expected` higher than is necessary may hurt model


### PR DESCRIPTION
* Update speaker diarization page to better clarify how `speaker_options` works
* Hide old legacy streaming page