### PR TITLE
fix(streaming): temp token api reference values

### DIFF
--- a/fern/pages/02-speech-to-text/universal-streaming/universal-streaming.mdx
+++ b/fern/pages/02-speech-to-text/universal-streaming/universal-streaming.mdx
@@ -925,7 +925,7 @@ You should generate this token on your server and pass it to the client.
 <Tab language="python-sdk" title="Python SDK" default>
 To generate a temporary token, call `StreamingClient.create_temporary_token()`.
 
-Use the `expires_in_seconds` parameter to specify the duration for which the token will remain valid and use the `max_session_duration_seconds` parameter to specify the desired maximum duration for the session started using this token.
+Use the `expires_in_seconds` parameter to specify the duration for which the token will remain valid. Optionally, use the `max_session_duration_seconds` parameter to specify the desired maximum duration for the session started using this token.
 
 ```python
 client = StreamingClient(
@@ -935,7 +935,7 @@ client = StreamingClient(
     )
 )
 
-return client.create_temporary_token(expires_in_seconds=60, max_session_duration_seconds=3600)
+return client.create_temporary_token(expires_in_seconds=60)
 ```
 
 </Tab>
@@ -943,7 +943,7 @@ return client.create_temporary_token(expires_in_seconds=60, max_session_duration
 
 To generate a temporary token, make a `POST` request to the temporary [token endpoint](/docs/api-reference/streaming-api/generate-streaming-token).
 
-Use the `expires_in_seconds` parameter to specify the duration for which the token will remain valid.
+Use the `expires_in_seconds` parameter to specify the duration for which the token will remain valid. Optionally, use the `max_session_duration_seconds` parameter to specify the desired maximum duration for the session initialized using this token.
 
 ```python
 import requests
@@ -963,7 +963,7 @@ return data.get("token")
 
 To generate a temporary token, call `client.streaming.createTemporaryToken()`.
 
-Use the `expires_in_seconds` parameter to specify the duration for which the token will remain valid.
+Use the `expires_in_seconds` parameter to specify the duration for which the token will remain valid. Optionally, use the `max_session_duration_seconds` parameter to specify the desired maximum duration for the session started using this token.
 
 ```js
 const client = new AssemblyAI({ apiKey: "<YOUR_API_KEY>" });
@@ -975,7 +975,7 @@ const token = await client.streaming.createTemporaryToken({ expires_in_seconds: 
 
 To generate a temporary token, make a `POST` request to the temporary [token endpoint](/docs/api-reference/streaming-api/generate-streaming-token).
 
-Use the `expires_in` parameter to specify the duration for which the token will remain valid.
+Use the `expires_in_seconds` parameter to specify the duration for which the token will remain valid. Optionally, use the `max_session_duration_seconds` parameter to specify the desired maximum duration for the session started using this token.
 
 ```js
 const url = new URL("https://streaming.assemblyai.com/v3/token");
@@ -996,7 +996,7 @@ return data.token;
 </Tab>
 </Tabs>
 
-<Note>The expiration time must be a value between 60 and 360000 seconds.</Note>
+<Note>`expires_in_seconds` must be a value between `1` and `600` seconds. If specified, `max_session_duration_seconds` must be a value between `60` and `10800` seconds (defaults to maximum session duration of 3 hours).</Note>
 
 </Step>
 <Step>

--- a/streaming-token.yml
+++ b/streaming-token.yml
@@ -31,7 +31,7 @@ paths:
           in: query
           description: |
             The desired expiration time for the token in seconds.
-          required: false
+          required: true
           schema:
             type: integer
             minimum: 1
@@ -44,8 +44,10 @@ paths:
           required: false
           schema:
             type: integer
-            minimum: 1
+            minimum: 60
+            maximum: 10800
             example: 600
+            default: 10800
       responses:
         "200":
           description: Successfully generated temporary token


### PR DESCRIPTION
I've verified these values are correct by requesting our API directly. Use this curl command and change the values of `expires_in_seconds` and  `max_session_duration_seconds` above/below their limits. It should result in an error:

```curl
curl -G https://streaming.assemblyai.com/v3/token \
     -H "Authorization: <API_KEY>" \
     -d expires_in_seconds=600 \
     -d max_session_duration_seconds=10800
```