### PR TITLE
misc: changes on 5 sep

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -621,6 +621,7 @@ navigation:
                     slug: task-endpoint-ai-coach
                   - page: Generate Action Items with LeMUR
                     path: pages/05-guides/cookbooks/lemur/task-endpoint-action-items.mdx
+                    slug: task-endpoint-action-items
                   - page: Prompt A Structured Q&A Response Using LeMUR
                     path: pages/05-guides/cookbooks/lemur/task-endpoint-structured-QA.mdx
                     slug: task-endpoint-structured-QA

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1309,3 +1309,25 @@ redirects:
     destination: /docs/speech-to-text/universal-streaming/keyterms-prompting
   - source: /docs/speech-to-text/pre-recorded-audio/ald-99-early-access
     destination: /docs/speech-to-text/pre-recorded-audio/automatic-language-detection
+
+  # Redirects for common hallucinated URLS
+  - source: /docs/api-reference/streaming/realtime
+    destination: /docs/api-reference/streaming-api/streaming-api
+  - source: /docs/models/speech-to-text
+    destination: /docs/getting-started/models
+  - source: /docs/speech-to-text/configuration
+    destination: /docs/speech-to-text/pre-recorded-audio
+  - source: /docs/speech-to-text/streaming-audio
+    destination: /docs/speech-to-text/universal-streaming
+  - source: /docs/speech-to-text/transcription
+    destination: /docs/speech-to-text/pre-recorded-audio
+  - source: /docs/core-transcription/supported-languages
+    destination: /docs/speech-to-text/pre-recorded-audio/supported-languages
+  - source: /docs/lemur/lemur-pii-redaction
+    destination: /docs/guides/lemur-pii-redaction
+  - source: /docs/api-reference/transcript
+    destination: /docs/api-reference/transcripts/get
+  - source: /docs/api-reference/streaming/create-temporary-token
+    destination: /docs/api-reference/streaming-api/generate-streaming-token
+  - source: /docs/api-reference/streaming
+    destination: /docs/api-reference/streaming-api/streaming-api

--- a/fern/pages/01-getting-started/models.mdx
+++ b/fern/pages/01-getting-started/models.mdx
@@ -49,7 +49,7 @@ AssemblyAI offers several state-of-the-art speech recognition models, each optim
 #### Breakdown of Universal language support
 
 <AccordionGroup>
-  
+
   <Accordion title="High accuracy (≤ 10% WER)">
     English, Spanish, French, German, Indonesian, Italian, Japanese, Dutch, Polish, Portuguese, Russian, Turkish, Ukrainian, Catalan
   </Accordion>
@@ -67,10 +67,7 @@ AssemblyAI offers several state-of-the-art speech recognition models, each optim
 </Accordion>
 
 <Accordion title="Fair accuracy (>50% WER)">
-  Amharic, Assamese, Bengali, Gujarati, Hausa, Javanese, Georgian, Khmer,
-  Kannada, Luxembourgish, Lingala, Lao, Malayalam, Mongolian, Maltese, Burmese,
-  Nepali, Occitan, Punjabi, Pashto, Sindhi, Shona, Somali, Serbian, Telugu,
-  Tajik, Uzbek, Yoruba
+Albanian, Amharic, Assamese, Bashkir, Basque, Bengali, Breton, Burmese, Faroese, Georgian, Gujarati, Haitian, Hawaiian, Hausa, Javanese, Kannada, Khmer, Lao, Latin, Lingala, Luxembourgish, Malagasy, Malayalam, Maltese, Mongolian, Nepali, Norwegian Nynorsk, Occitan, Punjabi, Pashto, Sanskrit, Serbian, Sindhi, Sinhala, Shona, Somali, Sundanese, Tajik, Tatar, Telugu, Tibetan, Turkmen, Uzbek, Yiddish, Yoruba
 </Accordion>
 
 </AccordionGroup>


### PR DESCRIPTION
- fixes a broken link for a LeMUR cookbook
- adds a redirect for common hallucinated URLs
- adds missing languages into the Fair transcription category on our supported languages page