### PR TITLE
misc: changes on 15 sept

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1177,6 +1177,9 @@ navigation:
               - page: What are your support hours and response time SLAs?
                 path: pages/faq/company/what-are-your-support-hours-and-response-time-slas.mdx
                 slug: /what-are-your-support-hours-and-response-time-slas
+              - page: What is your API Uptime SLA?
+                path: pages/faq/company/what-is-your-api-uptime-sla.mdx
+                slug: /what-is-your-api-uptime-sla
   - tab: playground
   - tab: changelog
 colors:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1180,6 +1180,9 @@ navigation:
               - page: What is your API Uptime SLA?
                 path: pages/faq/company/what-is-your-api-uptime-sla.mdx
                 slug: /what-is-your-api-uptime-sla
+              - page: Where can I find AssemblyAI's product roadmap?
+                path: pages/faq/company/where-can-i-find-assemblyais-product-roadmap.mdx
+                slug: /where-can-i-find-assemblyais-product-roadmap
   - tab: playground
   - tab: changelog
 colors:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -223,8 +223,6 @@ navigation:
                     hidden: true
                   - page: Filler words
                     path: pages/02-speech-to-text/pre-recorded-audio/filler-words.mdx
-                  - page: Keyterms prompting (Slam-1)
-                    path: pages/02-speech-to-text/pre-recorded-audio/keyterms-prompting.mdx
                   - page: Profanity filtering
                     path: pages/02-speech-to-text/pre-recorded-audio/profanity-filtering.mdx
               - page: Set the start and end of the transcript
@@ -1303,6 +1301,8 @@ redirects:
     destination: /docs/speech-to-text/universal-streaming/keyterms-prompting
   - source: /docs/speech-to-text/pre-recorded-audio/ald-99-early-access
     destination: /docs/speech-to-text/pre-recorded-audio/automatic-language-detection
+  - source: /docs/speech-to-text/pre-recorded-audio/keyterms-prompting-slam-1
+    destination: /docs/speech-to-text/pre-recorded-audio/improving-transcript-accuracy
 
   # Redirects for common hallucinated URLS
   - source: /docs/api-reference/streaming/realtime

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/improving-transcript-accuracy.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/improving-transcript-accuracy.mdx
@@ -2,21 +2,13 @@
 title: "Improving Transcript Accuracy"
 ---
 
-For optimal transcription accuracy, we recommend using our `slam-1` model, which offers superior performance and fine-tuning capabilities. Here's how to get the best results:
-
 ## Using Slam-1 (Recommended)
-
-### Fine-tuning with `keyterms_prompt`
 
 Improve transcription accuracy by leveraging Slam-1's contextual understanding capabilities by prompting the model with certain words or phrases that are likely to appear frequently in your audio file.
 
 Rather than simply increasing the likelihood of detecting specific words, Slam-1's multi-modal architecture actually understands the semantic meaning and context of the terminology you provide, enhancing transcription quality not just of the exact terms you specify, but also related terminology, variations, and contextually similar phrases.
 
 Provide up to 1000 domain-specific words or phrases (maximum 6 words per phrase) that may appear in your audio using the optional `keyterms_prompt` parameter:
-
-<Warning>
-  This parameter is only supported when the `speech_model` is set to `"slam-1"`.
-</Warning>
 
 <Tabs groupId="language">
   <Tab language="python" title="Python" default>
@@ -108,17 +100,16 @@ For optimal results, use shorter phrases when possible and be mindful of your to
 
 </Note>
 
-## Using Universal or Nano Models
+## Using `keyterms_prompt` with Universal (Beta)
 
-If you're currently using our `universal` or `nano` models and experiencing accuracy issues:
+<Warning>
 
-1. **Consider upgrading to Slam-1**: This is the recommended solution for better accuracy, especially with domain-specific content.
+Keyterms Prompting for Universal is currently in beta and available to all users free of charge. Pricing is still being finalized and may apply in the future.
 
-2. **Alternative approach (if Slam-1 isn't an option)**:
-   If you must continue using `universal` or `nano` models, you can try the LeMUR Custom Vocabulary approach as a workaround, though this may not provide the same level of accuracy as Slam-1 with `keyterms_prompt`.
+As we continue to develop this feature, functionality may evolve. For the latest updates and code examples, please check back on this page.
 
-   <Tip title="LeMUR Custom Vocabulary">
-     Learn more about using [LeMUR Custom
-     Vocabulary](/docs/guides/custom-vocab-lemur) if you need to improve
-     accuracy while using universal or nano models.
-   </Tip>
+</Warning>
+
+If you're currently using our `universal` model, the `keyterms_prompt` parameter is in Beta for English files.
+
+The maximum number of keyterms with Universal is 200.

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/improving-transcript-accuracy.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/improving-transcript-accuracy.mdx
@@ -100,7 +100,7 @@ For optimal results, use shorter phrases when possible and be mindful of your to
 
 </Note>
 
-## Using `keyterms_prompt` with Universal (Beta)
+## Using Universal (Beta)
 
 <Warning>
 
@@ -112,4 +112,83 @@ As we continue to develop this feature, functionality may evolve. For the latest
 
 If you're currently using our `universal` model, the `keyterms_prompt` parameter is in Beta for English files.
 
-The maximum number of keyterms with Universal is 200.
+The maximum number of keyterms with Universal is 200. Keyterms shorter than 5 characters or longer than 50 characters are ignored.
+
+<Tabs groupId="language">
+  <Tab language="python" title="Python" default>
+    ```python
+    import requests
+    import time
+
+    base_url = "https://api.assemblyai.com"
+    headers = {"authorization": "<YOUR_API_KEY>"}
+
+    data = {
+        "audio_url": "https://assembly.ai/sports_injuries.mp3",
+        "speech_model": "universal",
+        "keyterms_prompt": ['differential diagnosis', 'hypertension', 'Wellbutrin XL 150mg']
+    }
+
+    response = requests.post(base_url + "/v2/transcript", headers=headers, json=data)
+
+    if response.status_code != 200:
+        print(f"Error: {response.status_code}, Response: {response.text}")
+        response.raise_for_status()
+
+    transcript_response = response.json()
+    transcript_id = transcript_response["id"]
+    polling_endpoint = f"{base_url}/v2/transcript/{transcript_id}"
+
+    while True:
+        transcript = requests.get(polling_endpoint, headers=headers).json()
+        if transcript["status"] == "completed":
+            print(transcript["text"])
+            break
+        elif transcript["status"] == "error":
+            raise RuntimeError(f"Transcription failed: {transcript['error']}")
+        else:
+            time.sleep(3)
+    ```
+
+  </Tab>
+  <Tab language="javascript" title="JavaScript">
+    ```javascript
+      import axios from 'axios'
+
+      const baseUrl = 'https://api.assemblyai.com'
+
+      const headers = {
+        authorization: '<YOUR_API_KEY>'
+      }
+
+      const data = {
+        audio_url: 'https://assembly.ai/sports_injuries.mp3',
+        speech_model: 'universal',
+        keyterms_prompt: ['differential diagnosis', 'hypertension', 'Wellbutrin XL 150mg']
+      }
+
+      const url = `${baseUrl}/v2/transcript`
+      const response = await axios.post(url, data, { headers: headers })
+
+      const transcriptId = response.data.id
+      const pollingEndpoint = `${baseUrl}/v2/transcript/${transcriptId}`
+
+      while (true) {
+        const pollingResponse = await axios.get(pollingEndpoint, {
+          headers: headers
+        })
+        const transcriptionResult = pollingResponse.data
+
+        if (transcriptionResult.status === 'completed') {
+          console.log(transcriptionResult.text)
+          break
+        } else if (transcriptionResult.status === 'error') {
+          throw new Error(`Transcription failed: ${transcriptionResult.error}`)
+        } else {
+          await new Promise((resolve) => setTimeout(resolve, 3000))
+        }
+      }
+    ```
+
+  </Tab>
+</Tabs>

--- a/fern/pages/02-speech-to-text/pre-recorded-audio/improving-transcript-accuracy.mdx
+++ b/fern/pages/02-speech-to-text/pre-recorded-audio/improving-transcript-accuracy.mdx
@@ -104,7 +104,8 @@ For optimal results, use shorter phrases when possible and be mindful of your to
 
 <Warning>
 
-Keyterms Prompting for Universal is currently in beta and available to all users free of charge. Pricing is still being finalized and may apply in the future.
+`keyterms_prompt` for Universal is currently available at no additional cost while we gather feedback and refine functionality.
+Pricing may be introduced as the feature moves out of beta. We'll notify all users well in advance of any pricing changes.
 
 As we continue to develop this feature, functionality may evolve. For the latest updates and code examples, please check back on this page.
 

--- a/fern/pages/03-audio-intelligence/pii-redaction.mdx
+++ b/fern/pages/03-audio-intelligence/pii-redaction.mdx
@@ -133,7 +133,7 @@ print(transcript.text)
 
   </Tab>
   <Tab language="python" title="Python" default>
-  
+
   Enable Topic Detection by setting `redact_pii` to `True` in the JSON payload.
 
 Set `redact_pii_policies` to specify the information you want to redact. For the full list of policies, see [PII policies](#pii-policies).
@@ -186,7 +186,7 @@ while True:
 
   </Tab>
   <Tab language="javascript-sdk" title="JavaScript SDK">
-  
+
   Enable PII Redaction by setting `redact_pii` to `true` in the transcription
 config.
 
@@ -221,7 +221,7 @@ run();
 
   </Tab>
   <Tab language="javascript" title="JavaScript">
-  
+
     Enable Topic Detection by setting `redact_pii` to `true` in the JSON payload.
 
 Set `redact_pii_policies` to specify the information you want to redact. For the full list of policies, see [PII policies](#pii-policies).
@@ -279,7 +279,7 @@ while (true) {
 
   </Tab>
   <Tab language="csharp" title="C#">
-  
+
   Enable Topic Detection by setting `redact_pii` to `true` in the JSON payload.
 
 Set `redact_pii_policies` to specify the information you want to redact. For the full list of policies, see [PII policies](#pii-policies).
@@ -405,7 +405,7 @@ class Program
 
   </Tab>
 <Tab language="ruby" title="Ruby">
-  
+
   Enable Topic Detection by setting `redact_pii` to `true` in the JSON payload.
 
 Set `redact_pii_policies` to specify the information you want to redact. For the full list of policies, see [PII policies](#pii-policies).
@@ -478,7 +478,7 @@ end
 
   </Tab>
   <Tab language="php" title="PHP">
-  
+
     Enable Topic Detection by setting `redact_pii` to `true` in the JSON payload.
 
 Set `redact_pii_policies` to specify the information you want to redact. For the full list of policies, see [PII policies](#pii-policies).
@@ -593,11 +593,7 @@ Retrieve the redacted audio file using the `transcript_id` for a transcript wher
 
 </Tip>
 
-<Note title="Webhooks and PII Audio Redaction">
 
-If using webhooks with PII audio redaction enabled, you'll receive two webhook calls: the first when the redacted audio file is ready and the second when the request for transcription is completed. For more information about using webhooks, refer to our [webhook documentation](/docs/deployment/webhooks).
-
-</Note>
 
 <Tabs groupId="language">
   <Tab value="python-sdk" title="Python SDK" default>

--- a/fern/pages/05-guides/webhooks.mdx
+++ b/fern/pages/05-guides/webhooks.mdx
@@ -322,11 +322,7 @@ curl_close($curl);
 
 When the transcript is ready, AssemblyAI will send a `POST` HTTP request to the URL that you specified.
 
-<Note title="Webhooks and PII Audio Redaction">
 
-If using webhooks with PII audio redaction enabled, you'll receive two webhook calls: the first when the redacted audio file is ready and the second when the request for transcription is completed.
-
-</Note>
 
 <Note title="Static Webhook IP addresses">
 

--- a/fern/pages/faq/company/what-is-your-api-uptime-sla.mdx
+++ b/fern/pages/faq/company/what-is-your-api-uptime-sla.mdx
@@ -1,0 +1,15 @@
+---
+title: "What is your API Uptime SLA?"
+---
+
+Our SLA guarantees an  uptime of 99.9%  for our API service. This commitment means that, within a given year our service will not be unavailable for more than 8 hours and 46 minutes (526 mins).
+
+Our service's uptime is measured on an annual basis. We continuously monitor the availability of our API endpoints. A period is considered "downtime" when a significant number of requests to our API fail. Scheduled maintenance periods, which we announce in advance, are not included in this calculation.
+
+<Note>
+
+    We use Amazon Web Services (AWS) as our cloud provider. Our infrastructure is designed to be highly available, utilizing multiple AWS Availability Zones (AZs) to protect against single points of failure. Even if an entire AWS AZ were to go down, our service would continue operating from other healthy zones, however we must account for AWS' SLAs for uptime in our calculations.
+
+</Note>
+
+Please refer to our [Terms of Service](https://www.assemblyai.com/legal/terms-of-service) regarding credits you may be entitled to.

--- a/fern/pages/faq/company/where-can-i-find-assemblyais-product-roadmap.mdx
+++ b/fern/pages/faq/company/where-can-i-find-assemblyais-product-roadmap.mdx
@@ -1,0 +1,5 @@
+---
+title: "Where can I find AssemblyAI's product roadmap?"
+---
+
+ Our public product roadmap can be found [here](https://assemblyai.atlassian.net/jira/polaris/projects/AR/ideas/view/7299742).

--- a/openapi.yml
+++ b/openapi.yml
@@ -1474,8 +1474,7 @@ components:
         keyterms_prompt:
           x-label: Keyterms prompt
           description: |
-            <Warning>`keyterms_prompt` is only supported when the `speech_model` is specified as `slam-1`</Warning>
-            Improve accuracy with up to 1000 domain-specific words or phrases (maximum 6 words per phrase).
+            Improve accuracy with up to 200 (for Universal) or 1000 (for Slam-1) domain-specific words or phrases (maximum 6 words per phrase).
           type: array
           items:
             x-label: Keyterm

--- a/openapi.yml
+++ b/openapi.yml
@@ -2882,7 +2882,7 @@ components:
         keyterms_prompt:
           x-label: Keyterms prompt
           description: |
-            Improve accuracy with up to 1000 domain-specific words or phrases (maximum 6 words per phrase).
+            Improve accuracy with up to 200 (for Universal) or 1000 (for Slam-1) domain-specific words or phrases (maximum 6 words per phrase).
           type: array
           items:
             x-label: Keyterm

--- a/openapi.yml
+++ b/openapi.yml
@@ -554,6 +554,7 @@ paths:
         - transcript
       summary: Get redacted audio
       description: |
+        <Note>To retrieve the redacted audio on the EU server, replace `api.assemblyai.com` with `api.eu.assemblyai.com` in the `GET` request above.</Note>
         Retrieve the redacted audio object containing the status and URL to the redacted audio.
       operationId: getRedactedAudio
       x-fern-sdk-group-name: transcripts


### PR DESCRIPTION
* Remove prompting slam-1 page + include add redirect to the new page
* Update API reference for keyterms_prompt in GET to match POST
* add callout that the endpoint you call to get the redacted audio URL is different for NA and EU requests
* Update redact the Get redacted audio section of the API reference to reflect that this is supported for both regions
* Remove the callouts about the two webhooks calls for redacted audio
* new Pylon and Docs FAQ articles: 
  * where can I see your public product roadmap?
  * what is your API uptime SLA?