### PR TITLE
update verbiage to reflect 9/22/25 pricing changes

### DIFF
--- a/fern/pages/01-getting-started/models.mdx
+++ b/fern/pages/01-getting-started/models.mdx
@@ -80,7 +80,7 @@ Albanian, Amharic, Assamese, Bashkir, Basque, Bengali, Breton, Burmese, Faroese,
   - Fine-tuning support
   - Ideal for domain-specific terminology
 
-### Streaming
+### Universal-Streaming
 
 - **Best for**: Voice agents and real-time voice applications
 - **Key benefits**:
@@ -93,11 +93,13 @@ Albanian, Amharic, Assamese, Bashkir, Basque, Bengali, Breton, Burmese, Faroese,
 
 For detailed pricing information, visit our [pricing page](https://www.assemblyai.com/pricing).
 
-| Model     | Price per Hour | Volume discounts |
-| --------- | -------------- | ---------------- |
-| Universal | $0.27/hr       | Available        |
-| Slam-1    | $0.27/hr       | Available        |
-| Streaming | $0.15/hr       | Available        |
+| Model               | Price per Hour   | Volume discounts |
+| ------------------- | ---------------_ | ---------------- |
+| Universal           | $0.15/hr *       | Available        |
+| Slam-1              | $0.27/hr         | Available        |
+| Universal-Streaming | $0.15/hr *       | Available        |
+
+<Warning>* The prices shown above for Universal and Universal-Streaming are discounted rates for accounts that are opted in to data sharing. Rates may be different for accounts that are opted out of data sharing. See our [Pricing page](https://www.assemblyai.com/pricing) for full details on pricing.</Warning>
 
 For volume discounts, please reach out to sales@assemblyai.com.
 

--- a/fern/pages/faq/accounts-billing-pricing/how-does-pricing-work.mdx
+++ b/fern/pages/faq/accounts-billing-pricing/how-does-pricing-work.mdx
@@ -2,17 +2,15 @@
 title: "How does pricing work?"
 ---
 
-Our pricing is Pay-As-You-Go. For pre-recorded audio, pricing is based on the duration of the audio file submitted, the Speech Model selected, and the features used in the request. For streaming audio, pricing is based on the duration of the streaming session.
-
-Current pricing for pre-recorded audio on the Universal tier is \$0.27 per hour, and the Nano tier is \$0.12 per hour. Streaming STT is \$0.15 per hour. Audio Intelligence pricing depends on the models being used. LeMUR pricing is based on input and output size.
+Our pricing is Pay-As-You-Go. For pre-recorded audio, pricing is based on the duration of the audio file submitted, the Speech Model selected, and the features used in the request. For streaming audio, pricing is based on the duration of the streaming session. For LeMUR, pricing is based on input and output token size.
 
 You can find the breakdown of all our pricing information on our [Pricing page](https://www.assemblyai.com/pricing)!
 
 ## Pricing Structure (pre-recorded audio)
 
 - We charge based on the actual duration of your audio/video files in seconds
-- Rates are listed per hour for simplicity (e.g., \$0.27/hour), but we pro-rate to the exact second
-- Additional features (like Entity Detection) are also charged at their respective hourly rates
+- Rates are listed per hour for simplicity, but we pro-rate to the exact second for billing purposes
+- Additional features (like Entity Detection) are also charged at their respective hourly rates, pro-rated to the exact second
 
 ## Pricing Structure (streaming audio)
 
@@ -24,7 +22,3 @@ You can find the breakdown of all our pricing information on our [Pricing page](
 - Credits are deducted only after successful transcription completion
 - Failed transcripts are not charged
 - We don't offer unlimited usage plans or monthly subscriptions - we only charge you for what you use.
-
-## Example
-
-A 30-minute file at \$0.12/hour would cost \$0.06 (30 minutes = 0.5 hours × \$0.12). If you add Entity Detection at \$0.08/hour, the total would be \$0.10 `(\$0.12 + \$0.08) × 0.5`.


### PR DESCRIPTION
* update models page to show new prices, a callout on data opt out pricing, and added the full term "Universal-Streaming" where needed
* updated faq article to remove specific references to exact prices to make it more evergreen